### PR TITLE
feat: pagine di autenticazione coerenti e accessibili (Impeccable #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Changed
+- Pagine di autenticazione (accesso, registrazione, conferma email) uniformate a uno stile coerente basato sui token del tema: rimosso lo sfondo a gradiente, layout e tipografia allineati alle pagine di recupero password e pronti per il tema scuro.
+
+### Fixed
+- Accessibilità dei moduli di autenticazione: il pulsante mostra/nascondi password è ora raggiungibile da tastiera e annunciato dagli screen reader, i titoli di pagina sono heading semantici (`<h1>`) e gli stati di caricamento vengono annunciati.
+- Gli errori di accesso e registrazione restano visibili come messaggio sotto il modulo invece di comparire come notifica temporanea.
+- Risolto un raro reindirizzamento errato dalla pagina di conferma email alla registrazione.
+
 ## [1.6.3] - 2026-05-17
 
 ### Security

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../hooks/useAuth'
 import { loginSchema, signupSchema, type LoginFormData, type SignupFormData } from '../../lib/validations/auth.schemas'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
+import { Alert, AlertDescription } from '../ui/alert'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form'
 
 interface AuthFormProps {
@@ -28,6 +29,7 @@ export function AuthForm({ mode, onSuccess, prefillEmail, lockEmail, disableSubm
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
 
   // Use appropriate schema based on mode
   const schema = mode === 'login' ? loginSchema : signupSchema
@@ -50,6 +52,7 @@ export function AuthForm({ mode, onSuccess, prefillEmail, lockEmail, disableSubm
 
   const handleSubmit = async (data: LoginFormData | SignupFormData) => {
     setIsSubmitting(true)
+    setServerError(null)
 
     try {
       let result
@@ -65,6 +68,8 @@ export function AuthForm({ mode, onSuccess, prefillEmail, lockEmail, disableSubm
       if (result.success) {
         form.reset()
         onSuccess?.(data.email)
+      } else {
+        setServerError(result.error?.message ?? 'Si è verificato un errore. Riprova.')
       }
     } finally {
       setIsSubmitting(false)
@@ -145,7 +150,8 @@ export function AuthForm({ mode, onSuccess, prefillEmail, lockEmail, disableSubm
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    tabIndex={-1}
+                    aria-label={showPassword ? 'Nascondi password' : 'Mostra password'}
+                    aria-pressed={showPassword}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -194,7 +200,8 @@ export function AuthForm({ mode, onSuccess, prefillEmail, lockEmail, disableSubm
                       type="button"
                       onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                       className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      tabIndex={-1}
+                      aria-label={showConfirmPassword ? 'Nascondi conferma password' : 'Mostra conferma password'}
+                      aria-pressed={showConfirmPassword}
                     >
                       {showConfirmPassword ? (
                         <EyeOff className="h-4 w-4" />
@@ -208,6 +215,13 @@ export function AuthForm({ mode, onSuccess, prefillEmail, lockEmail, disableSubm
               </FormItem>
             )}
           />
+        )}
+
+        {/* Server-side error (persistent, near the action) */}
+        {serverError && (
+          <Alert variant="destructive">
+            <AlertDescription>{serverError}</AlertDescription>
+          </Alert>
         )}
 
         {/* Submit Button */}

--- a/src/components/auth/AuthLoadingScreen.tsx
+++ b/src/components/auth/AuthLoadingScreen.tsx
@@ -1,0 +1,14 @@
+/**
+ * Full-screen loading indicator shared by the auth pages while the
+ * authentication status is being resolved.
+ */
+export function AuthLoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center" role="status">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
+        <p className="mt-4 text-sm text-muted-foreground">Caricamento...</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -13,9 +13,9 @@ export function ProtectedRoute() {
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="text-center">
+        <div className="text-center" role="status">
           <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
-          <p className="mt-4 text-sm text-slate-600">Caricamento...</p>
+          <p className="mt-4 text-sm text-muted-foreground">Caricamento...</p>
         </div>
       </div>
     )

--- a/src/components/auth/__tests__/AuthForm.test.tsx
+++ b/src/components/auth/__tests__/AuthForm.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom/vitest'
+import { AuthForm } from '../AuthForm'
+
+const { mockSignIn, mockSignUp } = vi.hoisted(() => ({
+  mockSignIn: vi.fn(),
+  mockSignUp: vi.fn(),
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ signIn: mockSignIn, signUp: mockSignUp }),
+}))
+
+describe('AuthForm — accessibilità ed errori', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('il toggle password ha un nome accessibile ed è raggiungibile da tastiera', async () => {
+    render(<AuthForm mode="login" />)
+
+    const toggle = screen.getByRole('button', { name: /mostra password/i })
+    expect(toggle).toBeInTheDocument()
+    // P2 fix: non più tabIndex={-1}
+    expect(toggle).not.toHaveAttribute('tabindex', '-1')
+
+    await userEvent.click(toggle)
+    expect(
+      screen.getByRole('button', { name: /nascondi password/i })
+    ).toBeInTheDocument()
+  })
+
+  it('mostra un errore inline persistente (role=alert) quando il login fallisce', async () => {
+    mockSignIn.mockResolvedValue({
+      success: false,
+      error: new Error('Credenziali non valide'),
+    })
+
+    render(<AuthForm mode="login" />)
+    await userEvent.type(screen.getByPlaceholderText('tua@email.com'),'mario@example.com')
+    await userEvent.type(screen.getByPlaceholderText('••••••••'), 'qualsiasi')
+    await userEvent.click(screen.getByRole('button', { name: 'Accedi' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Credenziali non valide')
+  })
+
+  it('non chiama signIn quando la email non è valida (la validazione blocca il submit)', async () => {
+    render(<AuthForm mode="login" />)
+    await userEvent.type(screen.getByPlaceholderText('tua@email.com'), 'non-una-email')
+    await userEvent.type(screen.getByPlaceholderText('••••••••'), 'qualsiasi')
+    await userEvent.click(screen.getByRole('button', { name: 'Accedi' }))
+
+    // Con una email valida signIn verrebbe chiamata (vedi test sopra): diamo tempo
+    // al resolver async, poi verifichiamo che NON sia stata invocata.
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(mockSignIn).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -18,7 +18,7 @@ export function useAuth() {
     const { user, error } = await authService.signUp(email, password, fullName)
 
     if (error) {
-      toast.error(error.message)
+      // Error surfaced inline by AuthForm, not as a transient toast
       return { success: false, error }
     }
 
@@ -36,7 +36,7 @@ export function useAuth() {
     const { user, error } = await authService.signIn(email, password)
 
     if (error) {
-      toast.error(error.message)
+      // Error surfaced inline by AuthForm, not as a transient toast
       return { success: false, error }
     }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { AuthForm } from '../components/auth/AuthForm'
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card'
+import { AuthLoadingScreen } from '../components/auth/AuthLoadingScreen'
 import { Footer } from '../components/layout/Footer'
 import { useAuth } from '../hooks/useAuth'
 import { useDocumentMeta } from '../hooks/useDocumentMeta'
@@ -73,25 +73,16 @@ export function LoginPage() {
 
   // Show loading or nothing while checking auth status
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100">
-        <div className="text-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
-          <p className="mt-4 text-sm text-slate-600">Caricamento...</p>
-        </div>
-      </div>
-    )
+    return <AuthLoadingScreen />
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-50 to-slate-100">
+    <div className="flex min-h-screen flex-col">
       <div className="flex-1 flex items-center justify-center p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="space-y-1">
-            <CardTitle className="text-2xl font-bold text-center">
-              Accedi a entro
-            </CardTitle>
-            <CardDescription className="text-center">
+        <div className="w-full max-w-md space-y-8">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold tracking-tight">Accedi a entro</h1>
+            <p className="mt-2 text-muted-foreground">
               {inviteLoading ? (
                 <span className="flex items-center justify-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -104,13 +95,15 @@ export function LoginPage() {
               ) : (
                 'Inserisci le tue credenziali per accedere'
               )}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            </p>
+          </div>
+
+          <div className="rounded-lg border bg-card p-6">
             <AuthForm mode="login" onSuccess={handleSuccess} />
-          </CardContent>
-          <CardFooter className="flex flex-col space-y-2">
-            <div className="text-sm text-center text-slate-600">
+          </div>
+
+          <div className="space-y-2 text-center text-sm text-muted-foreground">
+            <div>
               Non hai un account?{' '}
               <Link
                 to={inviteToken ? `/signup?invite_token=${inviteToken}` : '/signup'}
@@ -119,16 +112,16 @@ export function LoginPage() {
                 Registrati
               </Link>
             </div>
-            <div className="text-sm text-center text-slate-600">
+            <div>
               <Link
                 to="/forgot-password"
-                className="font-medium text-slate-600 hover:text-primary hover:underline"
+                className="font-medium text-muted-foreground hover:text-primary hover:underline"
               >
                 Password dimenticata?
               </Link>
             </div>
-          </CardFooter>
-        </Card>
+          </div>
+        </div>
       </div>
       <Footer />
     </div>

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -82,7 +82,8 @@ export default function ResetPasswordPage() {
                           type="button"
                           onClick={() => setShowPassword(!showPassword)}
                           className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                          tabIndex={-1}
+                          aria-label={showPassword ? 'Nascondi password' : 'Mostra password'}
+                          aria-pressed={showPassword}
                         >
                           {showPassword ? (
                             <EyeOff className="h-4 w-4" />
@@ -127,7 +128,8 @@ export default function ResetPasswordPage() {
                           type="button"
                           onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                           className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                          tabIndex={-1}
+                          aria-label={showConfirmPassword ? 'Nascondi conferma password' : 'Mostra conferma password'}
+                          aria-pressed={showConfirmPassword}
                         >
                           {showConfirmPassword ? (
                             <EyeOff className="h-4 w-4" />

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactNode } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { AuthForm } from '../components/auth/AuthForm'
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card'
+import { AuthLoadingScreen } from '../components/auth/AuthLoadingScreen'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -123,30 +123,21 @@ export function SignUpPage() {
   }
 
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100">
-        <div className="text-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
-          <p className="mt-4 text-sm text-slate-600">Caricamento...</p>
-        </div>
-      </div>
-    )
+    return <AuthLoadingScreen />
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-50 to-slate-100">
+    <div className="flex min-h-screen flex-col">
       <div className="flex-1 flex items-center justify-center p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="space-y-1">
-            <CardTitle className="text-2xl font-bold text-center">
-              Crea il tuo account
-            </CardTitle>
-            <CardDescription className="text-center">
+        <div className="w-full max-w-md space-y-8">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold tracking-tight">Crea il tuo account</h1>
+            <p className="mt-2 text-muted-foreground">
               {getSignUpDescription(inviteLoading, inviteValid, inviteCreatorName)}
-            </CardDescription>
-          </CardHeader>
+            </p>
+          </div>
 
-          <CardContent>
+          <div className="rounded-lg border bg-card p-6">
             {/* Input codice manuale */}
             {!inviteValid && !inviteCode && (
               <div className="mb-4">
@@ -200,9 +191,9 @@ export function SignUpPage() {
                 id="terms"
                 checked={termsAccepted}
                 onChange={(e) => setTermsAccepted(e.target.checked)}
-                className="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                className="mt-1 h-4 w-4 rounded border-input text-primary focus:ring-primary"
               />
-              <label htmlFor="terms" className="text-sm text-slate-600">
+              <label htmlFor="terms" className="text-sm text-muted-foreground">
                 Accetto i{' '}
                 <a
                   href="https://app.legalblink.it/api/documents/697e24efc95cff002359012c/condizioni-d'uso-del-sito-it"
@@ -223,20 +214,18 @@ export function SignUpPage() {
                 </a>
               </label>
             </div>
-          </CardContent>
+          </div>
 
-          <CardFooter className="flex flex-col space-y-2">
-            <div className="text-sm text-center text-slate-600">
-              Hai già un account?{' '}
-              <Link
-                to="/login"
-                className="font-medium text-primary hover:underline"
-              >
-                Accedi
-              </Link>
-            </div>
-          </CardFooter>
-        </Card>
+          <div className="text-center text-sm text-muted-foreground">
+            Hai già un account?{' '}
+            <Link
+              to="/login"
+              className="font-medium text-primary hover:underline"
+            >
+              Accedi
+            </Link>
+          </div>
+        </div>
       </div>
       <Footer />
     </div>

--- a/src/pages/VerifyEmailPage.tsx
+++ b/src/pages/VerifyEmailPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card'
+import { AuthLoadingScreen } from '../components/auth/AuthLoadingScreen'
 import { Button } from '../components/ui/button'
 import { Footer } from '../components/layout/Footer'
 import { useAuth } from '../hooks/useAuth'
@@ -37,8 +37,14 @@ export function VerifyEmailPage() {
   const [email, setEmail] = useState<string>('')
   const [isResending, setIsResending] = useState(false)
   const [resendSuccess, setResendSuccess] = useState(false)
+  // Guard against React StrictMode double-invoking the effect (which would
+  // consume the one-shot sessionStorage email and wrongly redirect to /signup)
+  const handledRef = useRef(false)
 
   useEffect(() => {
+    if (handledRef.current) return
+    handledRef.current = true
+
     async function loadEmail() {
       // Try to get email from sessionStorage first (secure, not in URL)
       const sessionEmail = sessionStorage.getItem('verify_email')
@@ -110,21 +116,14 @@ export function VerifyEmailPage() {
   }
 
   if (authLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100">
-        <div className="text-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
-          <p className="mt-4 text-sm text-slate-600">Caricamento...</p>
-        </div>
-      </div>
-    )
+    return <AuthLoadingScreen />
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-50 to-slate-100">
+    <div className="flex min-h-screen flex-col">
       <div className="flex-1 flex items-center justify-center p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="space-y-1 text-center">
+        <div className="w-full max-w-md space-y-8">
+          <div className="text-center">
             <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
               {resendSuccess ? (
                 <CheckCircle2 className="h-10 w-10 text-primary" />
@@ -132,25 +131,21 @@ export function VerifyEmailPage() {
                 <Mail className="h-10 w-10 text-primary" />
               )}
             </div>
-            <CardTitle className="text-2xl font-bold">
-              Controlla la tua email
-            </CardTitle>
-            <CardDescription className="text-base">
-              Ti abbiamo inviato un link di conferma
-            </CardDescription>
-          </CardHeader>
+            <h1 className="text-2xl font-bold tracking-tight">Controlla la tua email</h1>
+            <p className="mt-2 text-muted-foreground">Ti abbiamo inviato un link di conferma</p>
+          </div>
 
-          <CardContent className="space-y-4">
-            <div className="rounded-lg bg-slate-50 p-4 text-center">
-              <p className="text-sm text-slate-600 mb-2">
+          <div className="rounded-lg border bg-card p-6 space-y-4">
+            <div className="rounded-lg bg-muted p-4 text-center">
+              <p className="text-sm text-muted-foreground mb-2">
                 Email inviata a:
               </p>
-              <p className="font-medium text-slate-900 break-all">
+              <p className="font-medium text-foreground break-all">
                 {email}
               </p>
             </div>
 
-            <div className="space-y-3 text-sm text-slate-600">
+            <div className="space-y-3 text-sm text-muted-foreground">
               <p>
                 <strong>Prossimi passi:</strong>
               </p>
@@ -168,13 +163,13 @@ export function VerifyEmailPage() {
                   <span className="w-full border-t" />
                 </div>
                 <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-white px-2 text-muted-foreground">
+                  <span className="bg-card px-2 text-muted-foreground">
                     Non hai ricevuto l'email?
                   </span>
                 </div>
               </div>
 
-              <div className="text-sm text-slate-600 space-y-2">
+              <div className="text-sm text-muted-foreground space-y-2">
                 <p>Controlla la cartella spam o promozioni</p>
                 <Button
                   variant="outline"
@@ -186,10 +181,10 @@ export function VerifyEmailPage() {
                 </Button>
               </div>
             </div>
-          </CardContent>
+          </div>
 
-          <CardFooter className="flex flex-col space-y-2 text-center">
-            <div className="text-sm text-slate-600">
+          <div className="space-y-2 text-center text-sm text-muted-foreground">
+            <div>
               <Link
                 to="/login"
                 className="font-medium text-primary hover:underline"
@@ -197,7 +192,7 @@ export function VerifyEmailPage() {
                 Torna al login
               </Link>
             </div>
-            <div className="text-sm text-slate-600">
+            <div>
               Email sbagliata?{' '}
               <Link
                 to="/signup"
@@ -206,8 +201,8 @@ export function VerifyEmailPage() {
                 Registrati di nuovo
               </Link>
             </div>
-          </CardFooter>
-        </Card>
+          </div>
+        </div>
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
## Fase B — unità Auth (#19)

Implementa i fix decisi dopo la critique/audit di Impeccable sul flusso di autenticazione (critique 32/40, audit ~16/20).

### Cosa cambia
- **Coerenza visiva (P1)**: accesso, registrazione e conferma email passano allo stesso scaffold sobrio delle pagine di recupero password — `<h1>` reale, pannello `rounded-lg border bg-card`, niente più `bg-gradient` né colori `slate/gray` raw. **Dark-mode ready** (solo token del tema).
- **A11y (P2)**: toggle mostra/nascondi password con `aria-label` + `aria-pressed` e raggiungibile da tastiera (rimosso `tabIndex={-1}`); titoli semantici `<h1>`; `role="status"` sugli spinner di caricamento.
- **Errori inline (P3)**: gli errori di accesso/registrazione restano visibili sotto il modulo (`Alert`) invece di un toast effimero; `useAuth` non emette più toast d'errore per `signIn`/`signUp`.
- **Idempotenza (P3)**: `VerifyEmailPage` usa un `useRef` guard, così l'effetto one-shot non viene consumato due volte sotto React StrictMode (niente più redirect errato a /signup).
- **Pulizia**: estratto `AuthLoadingScreen` condiviso (spinner duplicato nelle 3 pagine).

### Verifica
- `npx tsc -b` ✅ · `npm test` ✅ **25/25** (nuovi test `AuthForm`: a11y toggle, errore inline, gate validazione)
- `detect` sui file Auth: 0/41
- Screenshot mobile (414×896) ricatturati: login/signup/verify ora coerenti con forgot/reset

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)