### PR TITLE
feat: tokenizza colori e accessibilità della Dashboard (Impeccable #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Added
+- Colori semantici per gli stati di scadenza ("in scadenza" ambra, "fresco" verde) come token del tema: ora gli stati si adattano correttamente al tema scuro e restano coerenti con l'identità dell'app.
+
 ### Changed
 - Pagine di autenticazione (accesso, registrazione, conferma email) uniformate a uno stile coerente basato sui token del tema: rimosso lo sfondo a gradiente, layout e tipografia allineati alle pagine di recupero password e pronti per il tema scuro.
+- Dashboard e lista alimenti allineate all'identità verde del brand: lo stato selezionato delle statistiche rapide (Totali / In scadenza / Scaduti) usa ora il verde del brand invece del blu, e la card "Come funziona" passa da un tema blu a uno coerente col brand.
 
 ### Fixed
 - Accessibilità dei moduli di autenticazione: il pulsante mostra/nascondi password è ora raggiungibile da tastiera e annunciato dagli screen reader, i titoli di pagina sono heading semantici (`<h1>`) e gli stati di caricamento vengono annunciati.
 - Gli errori di accesso e registrazione restano visibili come messaggio sotto il modulo invece di comparire come notifica temporanea.
 - Risolto un raro reindirizzamento errato dalla pagina di conferma email alla registrazione.
+- Tema scuro della Dashboard: i badge di scadenza degli alimenti e i conteggi per giorno del calendario ora si adattano allo sfondo scuro invece di restare riquadri chiari poco leggibili.
+- Caricamento di lista e calendario ora annunciato agli screen reader.
+- Etichetta di scadenza al singolare corretta ("1 giorno" invece di "1 giorni"); nome dell'alimento reso come heading per una navigazione più chiara con screen reader; pulsanti Lista/Calendario portati a un'area tattile di almeno 44px.
 
 ## [1.6.3] - 2026-05-17
 

--- a/src/components/foods/DashboardStats.tsx
+++ b/src/components/foods/DashboardStats.tsx
@@ -8,14 +8,18 @@ interface DashboardStatsProps {
   onQuickFilter: (status: 'all' | 'expiring_soon' | 'expired') => void
 }
 
+const STAT_CARD_BASE =
+  "text-left transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg border bg-card text-card-foreground shadow"
+const STAT_CARD_SELECTED = 'ring-2 ring-primary'
+
 export function DashboardStats({ stats, currentStatus, onQuickFilter }: DashboardStatsProps) {
   return (
     <div className="grid grid-cols-3 gap-3" role="group" aria-label="Statistiche rapide">
       <button
         onClick={() => onQuickFilter('all')}
         className={cn(
-          "text-left transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg border bg-card text-card-foreground shadow",
-          !currentStatus || currentStatus === 'all' ? 'ring-2 ring-blue-500' : ''
+          STAT_CARD_BASE,
+          (!currentStatus || currentStatus === 'all') && STAT_CARD_SELECTED
         )}
         aria-label={`Mostra tutti gli alimenti (${stats.total})`}
         aria-pressed={!currentStatus || currentStatus === 'all'}
@@ -30,14 +34,14 @@ export function DashboardStats({ stats, currentStatus, onQuickFilter }: Dashboar
       <button
         onClick={() => onQuickFilter('expiring_soon')}
         className={cn(
-          "text-left transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg border bg-card text-card-foreground shadow",
-          currentStatus === 'expiring_soon' ? 'ring-2 ring-orange-500' : ''
+          STAT_CARD_BASE,
+          currentStatus === 'expiring_soon' && STAT_CARD_SELECTED
         )}
         aria-label={`Mostra alimenti in scadenza (${stats.expiringSoon})`}
         aria-pressed={currentStatus === 'expiring_soon'}
       >
         <div className="p-4 flex flex-col items-center text-center">
-          <CalendarDays className="h-6 w-6 text-orange-600 mb-2" aria-hidden="true" />
+          <CalendarDays className="h-6 w-6 text-warning mb-2" aria-hidden="true" />
           <div className="text-2xl font-bold mb-1">{stats.expiringSoon}</div>
           <p className="text-xs text-muted-foreground leading-tight">In scadenza</p>
         </div>
@@ -46,14 +50,14 @@ export function DashboardStats({ stats, currentStatus, onQuickFilter }: Dashboar
       <button
         onClick={() => onQuickFilter('expired')}
         className={cn(
-          "text-left transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg border bg-card text-card-foreground shadow",
-          currentStatus === 'expired' ? 'ring-2 ring-red-500' : ''
+          STAT_CARD_BASE,
+          currentStatus === 'expired' && STAT_CARD_SELECTED
         )}
         aria-label={`Mostra alimenti scaduti (${stats.expired})`}
         aria-pressed={currentStatus === 'expired'}
       >
         <div className="p-4 flex flex-col items-center text-center">
-          <AlertTriangle className="h-6 w-6 text-red-600 mb-2" aria-hidden="true" />
+          <AlertTriangle className="h-6 w-6 text-destructive mb-2" aria-hidden="true" />
           <div className="text-2xl font-bold mb-1">{stats.expired}</div>
           <p className="text-xs text-muted-foreground leading-tight">Scaduti</p>
         </div>

--- a/src/components/foods/DayColumn.tsx
+++ b/src/components/foods/DayColumn.tsx
@@ -23,7 +23,7 @@ export function DayColumn({ date, foods, onEdit }: DayColumnProps) {
         <div className="text-sm font-medium text-foreground mb-1">
           {format(date, 'EEEE dd MMM', { locale: it })}
         </div>
-        <span className="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 text-blue-800">
+        <span className="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-secondary text-secondary-foreground">
           {itemCount} {itemCount === 1 ? 'alimento' : 'alimenti'}
         </span>
       </div>
@@ -40,7 +40,7 @@ export function DayColumn({ date, foods, onEdit }: DayColumnProps) {
           ))
         ) : (
           <div className="flex flex-col items-center justify-center py-8 text-center">
-            <CheckCircle className="h-8 w-8 text-green-400 mb-2" />
+            <CheckCircle className="h-8 w-8 text-success mb-2" />
             <p className="text-xs text-muted-foreground/70">Nessuna scadenza</p>
           </div>
         )}

--- a/src/components/foods/FoodCard.tsx
+++ b/src/components/foods/FoodCard.tsx
@@ -34,20 +34,18 @@ function getExpiryStatus(expiryDate: string): {
   expiry.setHours(0, 0, 0, 0)
 
   const daysUntilExpiry = differenceInDays(expiry, now)
+  const dayLabel = `${daysUntilExpiry} ${daysUntilExpiry === 1 ? 'giorno' : 'giorni'}`
 
   if (daysUntilExpiry < 0) {
-    return { status: 'expired', colorClasses: 'bg-red-100 text-red-800 border-red-200', badgeText: 'Scaduto', daysUntilExpiry }
+    return { status: 'expired', colorClasses: 'bg-destructive text-destructive-foreground border-transparent', badgeText: 'Scaduto', daysUntilExpiry }
   }
   if (daysUntilExpiry === 0) {
-    return { status: 'critical', colorClasses: 'bg-red-100 text-red-800 border-red-200', badgeText: 'Scade oggi', daysUntilExpiry }
-  }
-  if (daysUntilExpiry <= 3) {
-    return { status: 'critical', colorClasses: 'bg-orange-100 text-orange-800 border-orange-200', badgeText: `${daysUntilExpiry} giorni`, daysUntilExpiry }
+    return { status: 'critical', colorClasses: 'bg-destructive text-destructive-foreground border-transparent', badgeText: 'Scade oggi', daysUntilExpiry }
   }
   if (daysUntilExpiry <= 7) {
-    return { status: 'warning', colorClasses: 'bg-yellow-100 text-yellow-800 border-yellow-200', badgeText: `${daysUntilExpiry} giorni`, daysUntilExpiry }
+    return { status: 'warning', colorClasses: 'bg-warning/10 text-warning border-warning/30', badgeText: dayLabel, daysUntilExpiry }
   }
-  return { status: 'good', colorClasses: 'bg-green-100 text-green-800 border-green-200', badgeText: `${daysUntilExpiry} giorni`, daysUntilExpiry }
+  return { status: 'good', colorClasses: 'bg-success/10 text-success border-success/30', badgeText: dayLabel, daysUntilExpiry }
 }
 
 const STORAGE_LABELS: Record<Food['storage_location'], string> = {
@@ -83,7 +81,7 @@ function getImageState(
  * FoodCard Component - Displays a single food item with expiry status
  */
 export function FoodCard({ food, category, onEdit, onDelete, showHintAnimation = false }: FoodCardProps) {
-  const { colorClasses, badgeText, daysUntilExpiry } = getExpiryStatus(food.expiry_date)
+  const { status, colorClasses, badgeText, daysUntilExpiry } = getExpiryStatus(food.expiry_date)
   const formattedExpiryDate = format(new Date(food.expiry_date), 'dd MMM yyyy', { locale: it })
 
   // Generate signed URL for private image
@@ -102,14 +100,15 @@ export function FoodCard({ food, category, onEdit, onDelete, showHintAnimation =
       <Card
         className={cn(
           'hover:shadow-md transition-shadow',
-          daysUntilExpiry <= 3 && 'border-orange-300',
-          isRemoteUpdate && 'ring-2 ring-blue-500 animate-pulse'
+          (status === 'expired' || status === 'critical') && 'border-destructive/40',
+          status === 'warning' && daysUntilExpiry <= 3 && 'border-warning/50',
+          isRemoteUpdate && 'ring-2 ring-primary animate-pulse'
         )}
       >
         <CardHeader className="pb-3">
           <div className="flex items-start justify-between gap-2">
             <div className="flex-1">
-              <CardTitle className="text-lg font-semibold text-foreground line-clamp-2">
+              <CardTitle as="h3" className="text-lg font-semibold text-foreground line-clamp-2">
                 {food.name}
                 {food.quantity && (
                   <span className="font-normal text-muted-foreground ml-1">
@@ -221,7 +220,7 @@ export function FoodCard({ food, category, onEdit, onDelete, showHintAnimation =
             variant="outline"
             size="sm"
             onClick={() => onDelete(food)}
-            className="flex-1 text-red-600 hover:text-red-700 hover:bg-red-100 dark:hover:bg-red-900/20"
+            className="flex-1 text-destructive hover:text-destructive hover:bg-destructive/10"
             aria-label={`Elimina ${food.name}`}
           >
             <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" />

--- a/src/components/foods/InstructionCard.tsx
+++ b/src/components/foods/InstructionCard.tsx
@@ -21,11 +21,11 @@ export function InstructionCard({ onDismiss }: InstructionCardProps) {
       onDelete={onDismiss} // Swipe left dismisses the card
       showHintAnimation={true} // Always show animation on this card
     >
-      <Card className="border-2 border-dashed border-blue-300 bg-blue-50/30">
+      <Card className="border-2 border-dashed border-primary/30 bg-primary/5">
         <CardHeader className="pb-3">
           <div className="flex items-center gap-2">
-            <Info className="h-5 w-5 text-blue-600" />
-            <CardTitle className="text-lg font-semibold text-blue-900">
+            <Info className="h-5 w-5 text-primary" />
+            <CardTitle as="h3" className="text-lg font-semibold text-foreground">
               Come funziona
             </CardTitle>
           </div>
@@ -36,16 +36,16 @@ export function InstructionCard({ onDismiss }: InstructionCardProps) {
           <div className="space-y-3 text-sm">
             <p className="text-muted-foreground text-xs font-medium">Su smartphone</p>
 
-            <div className="flex items-start gap-3 bg-card rounded-lg p-3 border border-blue-200">
-              <ArrowRight className="h-5 w-5 text-green-600 flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3 bg-card rounded-lg p-3 border border-border">
+              <ArrowRight className="h-5 w-5 text-success flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-medium text-foreground">Swipe verso destra</p>
                 <p className="text-muted-foreground text-xs mt-0.5">Modifica un alimento</p>
               </div>
             </div>
 
-            <div className="flex items-start gap-3 bg-card rounded-lg p-3 border border-blue-200">
-              <ArrowLeft className="h-5 w-5 text-red-600 flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3 bg-card rounded-lg p-3 border border-border">
+              <ArrowLeft className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-medium text-foreground">Swipe verso sinistra</p>
                 <p className="text-muted-foreground text-xs mt-0.5">Elimina un alimento</p>
@@ -54,11 +54,11 @@ export function InstructionCard({ onDismiss }: InstructionCardProps) {
           </div>
 
           {/* Hint to dismiss */}
-          <div className="bg-blue-100 rounded-lg p-3 text-center">
-            <p className="text-xs text-blue-800 font-medium">
+          <div className="bg-primary/10 rounded-lg p-3 text-center">
+            <p className="text-xs text-foreground font-medium">
               💡 I tuoi alimenti appariranno qui
             </p>
-            <p className="text-xs text-blue-600 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               Fai swipe a sinistra per eliminare questa card
             </p>
           </div>

--- a/src/components/foods/WeekView.tsx
+++ b/src/components/foods/WeekView.tsx
@@ -44,7 +44,7 @@ export function WeekView({ foods, onEdit }: WeekViewProps) {
     return (
       <Card>
         <CardContent className="py-12 text-center">
-          <CheckCircle className="h-16 w-16 text-green-500 mx-auto mb-4" />
+          <CheckCircle className="h-16 w-16 text-success mx-auto mb-4" />
           <h3 className="text-lg font-semibold text-foreground mb-2">
             Ottimo! Nessun alimento in scadenza
           </h3>

--- a/src/components/foods/__tests__/DashboardStats.test.tsx
+++ b/src/components/foods/__tests__/DashboardStats.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { DashboardStats } from '../DashboardStats'
+
+afterEach(cleanup)
+
+const STATS = { total: 4, expiringSoon: 3, expired: 1 }
+
+describe('DashboardStats — quick filter', () => {
+  it('invoca onQuickFilter con lo stato corretto al click', () => {
+    const onQuickFilter = vi.fn()
+    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={onQuickFilter} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Mostra alimenti in scadenza/ }))
+    expect(onQuickFilter).toHaveBeenCalledWith('expiring_soon')
+
+    fireEvent.click(screen.getByRole('button', { name: /Mostra alimenti scaduti/ }))
+    expect(onQuickFilter).toHaveBeenCalledWith('expired')
+
+    fireEvent.click(screen.getByRole('button', { name: /Mostra tutti gli alimenti/ }))
+    expect(onQuickFilter).toHaveBeenCalledWith('all')
+  })
+
+  it('espone i conteggi nelle aria-label', () => {
+    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /Mostra tutti gli alimenti \(4\)/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Mostra alimenti in scadenza \(3\)/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Mostra alimenti scaduti \(1\)/ })).toBeTruthy()
+  })
+})
+
+describe('DashboardStats — identità di brand (una sola voce)', () => {
+  it('evidenzia la card selezionata con il ring verde brand, mai blu', () => {
+    const { rerender } = render(
+      <DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />
+    )
+    const all = screen.getByRole('button', { name: /Mostra tutti gli alimenti/ })
+    expect(all.className).toContain('ring-primary')
+    expect(all.getAttribute('aria-pressed')).toBe('true')
+
+    rerender(<DashboardStats stats={STATS} currentStatus="expired" onQuickFilter={vi.fn()} />)
+    const expired = screen.getByRole('button', { name: /Mostra alimenti scaduti/ })
+    expect(expired.className).toContain('ring-primary')
+    expect(expired.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('non usa nessun ring blu/arancio/rosso fuori-brand per la selezione', () => {
+    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />)
+    for (const btn of screen.getAllByRole('button')) {
+      expect(btn.className).not.toMatch(/ring-(blue|orange|red)-\d/)
+    }
+  })
+
+  it('imposta aria-pressed=false sulle card non selezionate', () => {
+    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />)
+    expect(
+      screen.getByRole('button', { name: /Mostra alimenti scaduti/ }).getAttribute('aria-pressed')
+    ).toBe('false')
+  })
+})

--- a/src/components/foods/__tests__/FoodCard.test.tsx
+++ b/src/components/foods/__tests__/FoodCard.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { FoodCard } from '../FoodCard'
+import type { Food } from '@/lib/foods'
+
+// useSignedUrl hits Supabase storage; stub it so the card renders offline.
+vi.mock('@/hooks/useSignedUrl', () => ({
+  useSignedUrl: () => ({ signedUrl: null, isLoading: false, error: null }),
+}))
+
+afterEach(cleanup)
+
+/** Build an expiry_date exactly `n` calendar days from today (timezone-safe). */
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + n)
+  return d.toISOString()
+}
+
+function makeFood(overrides: Partial<Food> = {}): Food {
+  return {
+    id: 'food-1',
+    name: 'Latte',
+    quantity: null,
+    quantity_unit: null,
+    expiry_date: daysFromNow(30),
+    image_url: null,
+    storage_location: 'fridge',
+    category_id: null,
+    notes: null,
+    ...overrides,
+  } as Food
+}
+
+function badge(text: string | RegExp) {
+  return screen.getByText(text)
+}
+
+describe('FoodCard — stato di scadenza (business rule)', () => {
+  it('mostra "Scaduto" con il token destructive per alimenti scaduti', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(-2) })} />)
+    const el = badge('Scaduto')
+    expect(el.className).toContain('bg-destructive')
+  })
+
+  it('mostra "Scade oggi" con il token destructive quando scade oggi', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(0) })} />)
+    const el = badge('Scade oggi')
+    expect(el.className).toContain('bg-destructive')
+  })
+
+  it('usa il token warning (ambra unica) per gli alimenti in scadenza entro 7 giorni', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(5) })} />)
+    const el = badge('5 giorni')
+    expect(el.className).toContain('text-warning')
+    expect(el.className).not.toMatch(/text-(yellow|orange)-\d/)
+  })
+
+  it('usa lo stesso token warning al confine dei 7 giorni', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(7) })} />)
+    expect(badge('7 giorni').className).toContain('text-warning')
+  })
+
+  it('usa il token success per alimenti freschi (oltre 7 giorni)', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(8) })} />)
+    const el = badge('8 giorni')
+    expect(el.className).toContain('text-success')
+    expect(el.className).not.toMatch(/text-green-\d/)
+  })
+})
+
+describe('FoodCard — pluralizzazione giorni', () => {
+  it('dice "1 giorno" al singolare', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(1) })} />)
+    expect(screen.getByText('1 giorno')).toBeTruthy()
+    expect(screen.queryByText('1 giorni')).toBeNull()
+  })
+
+  it('dice "N giorni" al plurale', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(3) })} />)
+    expect(screen.getByText('3 giorni')).toBeTruthy()
+  })
+})
+
+describe('FoodCard — accessibilità & identità', () => {
+  it('annuncia lo stato di scadenza con role=status + testo (mai solo colore)', () => {
+    render(<FoodCard food={makeFood({ expiry_date: daysFromNow(2) })} />)
+    const status = screen.getByRole('status')
+    expect(status.getAttribute('aria-label')).toContain('Stato scadenza')
+    expect(status.textContent).toContain('2 giorni')
+  })
+
+  it('rende il nome alimento come heading <h3>', () => {
+    render(<FoodCard food={makeFood({ name: 'Yogurt' })} />)
+    const heading = screen.getByRole('heading', { level: 3, name: /Yogurt/ })
+    expect(heading).toBeTruthy()
+  })
+})

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -30,10 +30,10 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement> & { as?: React.ElementType }
+>(({ className, as: Comp = "div", ...props }, ref) => (
+  <Comp
     ref={ref}
     className={cn("font-semibold leading-none tracking-tight", className)}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,12 @@
     --accent-foreground: 0 0% 9%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+    /* Stati di scadenza semantici (DESIGN.md §2): "in scadenza" = ambra, "ok/fresco" = verde.
+       Valori scuri per superare AA come testo su tinte chiare (badge soft). */
+    --warning: 25 90% 34%;
+    --warning-foreground: 0 0% 100%;
+    --success: 142 74% 26%;
+    --success-foreground: 0 0% 100%;
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
     --ring: 142.1 76.2% 36.3%;
@@ -48,6 +54,11 @@
     --accent-foreground: 0 0% 98%;
     --destructive: 0 72% 50%;
     --destructive-foreground: 0 0% 98%;
+    /* Varianti chiare per superare AA come testo su tinte scure in dark mode */
+    --warning: 40 96% 60%;
+    --warning-foreground: 20 14% 4%;
+    --success: 142 60% 62%;
+    --success-foreground: 144.9 80.4% 10%;
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 142.1 70.6% 45.3%;

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -253,10 +253,11 @@ export function DashboardPage() {
       />
 
       {/* Foods Grid */}
+      <h2 className="sr-only">I tuoi alimenti</h2>
       {foodsLoading ? (
-        <div className="flex items-center justify-center py-12">
+        <div className="flex items-center justify-center py-12" role="status" aria-live="polite">
           <div className="flex flex-col items-center gap-3">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary"></div>
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" aria-hidden="true"></div>
             <div className="text-muted-foreground">Caricamento alimenti...</div>
           </div>
         </div>
@@ -332,7 +333,7 @@ export function DashboardPage() {
               <button
                 onClick={() => handleViewModeChange('list')}
                 className={cn(
-                  'flex items-center gap-2 px-4 py-2 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                  'flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                   viewMode === 'list'
                     ? 'bg-primary text-primary-foreground'
                     : 'bg-muted text-muted-foreground hover:bg-muted/80'
@@ -347,7 +348,7 @@ export function DashboardPage() {
               <button
                 onClick={() => handleViewModeChange('calendar')}
                 className={cn(
-                  'flex items-center gap-2 px-4 py-2 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                  'flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                   viewMode === 'calendar'
                     ? 'bg-primary text-primary-foreground'
                     : 'bg-muted text-muted-foreground hover:bg-muted/80'
@@ -369,8 +370,8 @@ export function DashboardPage() {
           {/* Conditional View Rendering */}
           {viewMode === 'calendar' ? (
             <Suspense fallback={
-              <div className="flex items-center justify-center py-12">
-                <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary"></div>
+              <div className="flex items-center justify-center py-12" role="status" aria-label="Caricamento calendario">
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" aria-hidden="true"></div>
               </div>
             }>
               <WeekView
@@ -417,7 +418,7 @@ export function DashboardPage() {
       {/* Floating Action Button (FAB) - Mobile Only */}
       <button
         onClick={() => setIsAddDialogOpen(true)}
-        className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full bg-green-600 text-white shadow-lg hover:bg-green-700 active:scale-95 transition-all flex items-center justify-center sm:hidden"
+        className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 active:scale-95 transition-all flex items-center justify-center sm:hidden"
         aria-label="Aggiungi alimento"
       >
         <Plus className="h-6 w-6" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,6 +32,14 @@ export default {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",


### PR DESCRIPTION
Unità Impeccable #1 — Dashboard & lista alimenti (Fase B). Vedi `Closes #15` per i findings di Fase A.

## Causa-radice risolta
Quasi tutti i findings avevano la stessa origine: mancavano i token semantici per gli stati di scadenza e si usavano colori Tailwind grezzi (spesso blu, fuori-brand) che **non si adattavano al tema scuro**. Questa PR introduce il token system e ci allinea tutta la Dashboard.

## Cosa cambia

**Token (root)**
- Nuovi token `--warning` (ambra, "in scadenza") e `--success` (verde, "fresco") in `index.css` (light + dark) e `tailwind.config.js`. Valori scelti e **verificati numericamente per contrasto WCAG AA** come testo su tinta in entrambi i temi.

**P1 — identità di brand + dark mode**
- `DashboardStats`: ring di selezione ora **verde brand** (prima blu/arancio/rosso → tre colori diversi). Una sola voce.
- `FoodCard`: badge di scadenza tokenizzati e **leggibili in dark mode** (prima riquadri chiari abbaglianti). "Ambra unica" per ≤7 giorni, `destructive` per scaduto/oggi, `success` per fresco.
- `InstructionCard`: ri-tematizzata da blu a brand/neutro, completamente dark-adaptive.
- Conteggio per giorno del calendario (`DayColumn`) da blu fuori-brand a pill neutra che si adatta al tema.

**P2**
- FAB su `bg-primary` (prima `bg-green-600` hard-coded).
- Caricamento di lista e calendario annunciato agli screen reader (`role="status"` + `aria-live`).
- `CardTitle` con prop `as` retro-compatibile (default `div`); nome alimento reso come `<h3>` + heading di sezione `sr-only`.
- Icone statistiche e bottone elimina tokenizzati.

**P3 a basso costo**
- Pluralizzazione: "1 giorno" invece di "1 giorni".
- Area tattile dei toggle Lista/Calendario portata a ≥44px.

**Fuori scope (lasciati di proposito, per change-tracing)**
- Modifica/elimina solo-swipe su mobile: scelta touch-first deliberata (concordato di non toccarlo qui).
- Sfondi swipe `bg-green-500`/`bg-red-500` (colori d'azione fissi con icona bianca; tokenizzarli romperebbe il contrasto dell'icona in dark mode) e box note `bg-amber-100` (già dark-adaptive, affordance distinta).

## Verifica
- **Detect**: 0/41 · **Audit**: 14 → **19/20** · **Critique**: 31 → **34/40**
- `tsc --noEmit` ok · **39/39 test** (14 nuovi: stato scadenza ai confini 0/7/8 giorni, pluralizzazione, ring verde brand senza blu, `role=status`, heading `<h3>`)
- Verifica visiva mobile 414×896 (light + dark, lista popolata + calendario): badge e pill ora si adattano al tema scuro, ring verde, FAB verde.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)