### PR TITLE
feat: uniforma colori, accessibilità e touch del form alimento (Impeccable #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 ### Changed
 - Pagine di autenticazione (accesso, registrazione, conferma email) uniformate a uno stile coerente basato sui token del tema: rimosso lo sfondo a gradiente, layout e tipografia allineati alle pagine di recupero password e pronti per il tema scuro.
 - Dashboard e lista alimenti allineate all'identità verde del brand: lo stato selezionato delle statistiche rapide (Totali / In scadenza / Scaduti) usa ora il verde del brand invece del blu, e la card "Come funziona" passa da un tema blu a uno coerente col brand.
+- Form "Aggiungi/Modifica alimento": campi (nome, categoria, posizione, data, quantità) e pulsanti principali portati a un'area tattile di almeno 44px, più comoda da toccare con una mano.
 
 ### Fixed
 - Accessibilità dei moduli di autenticazione: il pulsante mostra/nascondi password è ora raggiungibile da tastiera e annunciato dagli screen reader, i titoli di pagina sono heading semantici (`<h1>`) e gli stati di caricamento vengono annunciati.
@@ -21,6 +22,10 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - Tema scuro della Dashboard: i badge di scadenza degli alimenti e i conteggi per giorno del calendario ora si adattano allo sfondo scuro invece di restare riquadri chiari poco leggibili.
 - Caricamento di lista e calendario ora annunciato agli screen reader.
 - Etichetta di scadenza al singolare corretta ("1 giorno" invece di "1 giorni"); nome dell'alimento reso come heading per una navigazione più chiara con screen reader; pulsanti Lista/Calendario portati a un'area tattile di almeno 44px.
+- Scanner barcode: i messaggi di errore della fotocamera sono ora in italiano e spiegano cosa fare (fotocamera non supportata dal browser, permesso negato, fotocamera occupata da un'altra app) invece del testo tecnico in inglese.
+- Caricamento foto dell'alimento: il pulsante "Rimuovi" è ora sempre visibile su smartphone (prima compariva solo al passaggio del mouse, di fatto irraggiungibile da touch).
+- Tema scuro del form alimento: anteprima foto, riquadri di errore e testi di aiuto del caricamento immagine si adattano ora allo sfondo scuro usando i colori del tema; il banner "alimento modificato da un altro utente" usa l'ambra di sistema.
+- Accessibilità del form alimento: gli stati di caricamento (scanner, conversione foto, salvataggio) sono annunciati agli screen reader e il pulsante "Scansiona Barcode" è identificabile dal suo testo visibile, utile per i comandi vocali.
 
 ## [1.6.3] - 2026-05-17
 

--- a/src/components/barcode/BarcodeScanner.tsx
+++ b/src/components/barcode/BarcodeScanner.tsx
@@ -17,6 +17,30 @@ interface BarcodeScannerProps {
 }
 
 /**
+ * Map raw camera/ZXing error strings (often English, e.g. "Not supported") to
+ * plain Italian guidance. Falls back to the original message when already localized.
+ */
+export function localizeScanError(message: string): string {
+  const m = message.toLowerCase()
+  if (m.includes('not supported') || m.includes('notsupported')) {
+    return 'Scanner non supportato su questo browser. Aggiornalo o usa un altro dispositivo.'
+  }
+  if (m.includes('not allowed') || m.includes('permission') || m.includes('denied')) {
+    return 'Permesso fotocamera negato. Abilitalo nelle impostazioni del browser e riprova.'
+  }
+  if (m.includes('not found') || m.includes('notfound')) {
+    return 'Nessuna fotocamera trovata sul dispositivo.'
+  }
+  if (m.includes('not readable') || m.includes('in use') || m.includes('notreadable')) {
+    return 'Fotocamera occupata da un\'altra app. Chiudila e riprova.'
+  }
+  if (m.includes('secure') || m.includes('https')) {
+    return 'Lo scanner richiede una connessione sicura (HTTPS).'
+  }
+  return message
+}
+
+/**
  * BarcodeScanner Component - Modal dialog for scanning barcodes
  * Uses @zxing/browser library to access device camera and scan EAN/UPC/QR barcodes
  */
@@ -112,9 +136,9 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
 
             {/* Loading state overlay */}
             {state === 'idle' && (
-              <div className="absolute inset-0 flex items-center justify-center">
+              <div className="absolute inset-0 flex items-center justify-center" role="status" aria-live="polite">
                 <div className="flex flex-col items-center gap-3 text-white">
-                  <Loader2 className="h-8 w-8 animate-spin" />
+                  <Loader2 className="h-8 w-8 animate-spin" aria-hidden="true" />
                   <p className="text-sm">Inizializzazione fotocamera...</p>
                 </div>
               </div>
@@ -122,9 +146,9 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
 
             {/* Processing overlay */}
             {isProcessing && (
-              <div className="absolute inset-0 bg-black/60 rounded-lg flex items-center justify-center">
+              <div className="absolute inset-0 bg-black/60 rounded-lg flex items-center justify-center" role="status" aria-live="polite">
                 <div className="bg-background p-4 rounded-lg flex flex-col items-center gap-2">
-                  <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                  <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden="true" />
                   <p className="text-sm font-medium">Elaborazione...</p>
                 </div>
               </div>
@@ -132,9 +156,9 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
 
             {/* Success overlay */}
             {isSuccess && scannedCode && (
-              <div className="absolute inset-0 bg-black/60 rounded-lg flex items-center justify-center">
+              <div className="absolute inset-0 bg-black/60 rounded-lg flex items-center justify-center" role="status" aria-live="polite">
                 <div className="bg-background p-4 rounded-lg flex flex-col items-center gap-2">
-                  <CheckCircle2 className="h-8 w-8 text-green-500" />
+                  <CheckCircle2 className="h-8 w-8 text-success" aria-hidden="true" />
                   <p className="text-sm font-medium">Codice riconosciuto!</p>
                   <p className="text-xs text-muted-foreground font-mono">{scannedCode}</p>
                 </div>
@@ -144,11 +168,11 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
 
           {/* Error message */}
           {isError && error && (
-            <div className="flex items-start gap-2 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
-              <AlertCircle className="h-5 w-5 flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-destructive/10 text-destructive text-sm" role="alert">
+              <AlertCircle className="h-5 w-5 flex-shrink-0 mt-0.5" aria-hidden="true" />
               <div>
                 <p className="font-medium">Errore</p>
-                <p className="text-xs mt-1">{error}</p>
+                <p className="text-xs mt-1">{localizeScanError(error)}</p>
               </div>
             </div>
           )}
@@ -160,7 +184,7 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
                 Posiziona il codice a barre all'interno del riquadro
               </p>
               <div className="flex items-center justify-center gap-2">
-                <div className="h-2 w-2 rounded-full bg-green-500 animate-pulse" />
+                <div className="h-2 w-2 rounded-full bg-primary animate-pulse" aria-hidden="true" />
                 <p className="text-xs text-muted-foreground">Scanner attivo</p>
               </div>
             </div>

--- a/src/components/barcode/__tests__/localizeScanError.test.ts
+++ b/src/components/barcode/__tests__/localizeScanError.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { localizeScanError } from '../BarcodeScanner'
+
+describe('localizeScanError', () => {
+  it('maps the raw "Not supported" browser error to Italian guidance', () => {
+    const out = localizeScanError('Not supported')
+    expect(out).not.toBe('Not supported')
+    expect(out.toLowerCase()).toContain('non supportato')
+  })
+
+  it('maps permission/NotAllowed errors to permission guidance', () => {
+    expect(localizeScanError('NotAllowedError: Permission denied').toLowerCase()).toContain('permesso')
+    expect(localizeScanError('The request is not allowed').toLowerCase()).toContain('permesso')
+  })
+
+  it('maps missing-camera and busy-camera errors', () => {
+    expect(localizeScanError('NotFoundError').toLowerCase()).toContain('nessuna fotocamera')
+    expect(localizeScanError('NotReadableError: Could not start video source').toLowerCase()).toContain('occupata')
+  })
+
+  it('passes through an already-Italian message unchanged', () => {
+    const msg = 'API fotocamera non disponibile su questo browser'
+    expect(localizeScanError(msg)).toBe(msg)
+  })
+})

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -61,6 +61,13 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
   // Prevent double submit (additional protection beyond isSubmitting)
   const isSubmittingRef = useRef(false)
 
+  // Keep latest onCancel in a ref so the realtime subscription effect below does
+  // not re-subscribe on every parent render (callers pass inline arrows).
+  const onCancelRef = useRef(onCancel)
+  useEffect(() => {
+    onCancelRef.current = onCancel
+  }, [onCancel])
+
   // Setup form with validation
   const form = useForm<FoodFormData>({
     resolver: zodResolver(foodFormSchema),
@@ -143,9 +150,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                     label: 'Ricarica',
                     onClick: () => {
                       // Close dialog to force refetch
-                      if (onCancel) {
-                        onCancel()
-                      }
+                      onCancelRef.current?.()
                     },
                   },
                 },
@@ -169,7 +174,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
         supabase.removeChannel(channel)
       }
     }
-  }, [mode, initialData?.id, onCancel])
+  }, [mode, initialData?.id])
 
   // Handle barcode scan success
   const handleBarcodeScanned = async (barcode: string) => {
@@ -255,7 +260,18 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
     <>
       {/* Barcode Scanner Modal - Lazy loaded */}
       {scannerOpen && (
-        <Suspense fallback={<div>Caricamento scanner...</div>}>
+        <Suspense
+          fallback={
+            <div
+              className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
+              role="status"
+              aria-live="polite"
+            >
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              Caricamento scanner...
+            </div>
+          }
+        >
           <BarcodeScanner
             open={scannerOpen}
             onOpenChange={setScannerOpen}
@@ -273,13 +289,13 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
         })} className="space-y-4">
           {/* Conflict Warning Banner */}
           {hasRemoteUpdate && (
-            <div className="flex items-start gap-3 p-4 rounded-lg border border-orange-200 bg-orange-50 dark:bg-orange-900/20 dark:border-orange-800">
-              <AlertTriangle className="h-5 w-5 text-orange-600 dark:text-orange-400 flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3 p-4 rounded-lg border border-warning/30 bg-warning/10" role="alert">
+              <AlertTriangle className="h-5 w-5 text-warning flex-shrink-0 mt-0.5" aria-hidden="true" />
               <div className="flex-1">
-                <p className="text-sm font-medium text-orange-900 dark:text-orange-200">
+                <p className="text-sm font-medium text-warning">
                   Alimento modificato remotamente
                 </p>
-                <p className="text-sm text-orange-700 dark:text-orange-300 mt-1">
+                <p className="text-sm text-foreground/90 mt-1">
                   Questo alimento è stato modificato da un altro utente mentre lo stavi modificando.
                   Puoi continuare a modificarlo (last-write-wins) o ricaricare per vedere le ultime modifiche.
                 </p>
@@ -316,8 +332,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                   variant="outline"
                   onClick={() => setScannerOpen(true)}
                   disabled={isSubmitting || isLoadingProduct}
-                  className="w-full bg-primary/10 dark:bg-primary/15"
-                  aria-label="Apri scanner barcode per compilare automaticamente i dati"
+                  className="h-11 w-full bg-primary/10 dark:bg-primary/15"
                 >
                   {isLoadingProduct ? (
                     <>
@@ -349,6 +364,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                   <FormControl>
                     <Input
                       placeholder="es. Latte intero"
+                      className="h-11"
                       disabled={isSubmitting || isLoadingProduct}
                       {...field}
                     />
@@ -367,7 +383,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                   <FormLabel>Categoria *</FormLabel>
                   <FormControl>
                     <select
-                      className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                      className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                       disabled={isSubmitting || categoriesLoading}
                       {...field}
                     >
@@ -393,7 +409,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                   <FormLabel>Posizione *</FormLabel>
                   <FormControl>
                     <select
-                      className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                      className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                       disabled={isSubmitting}
                       {...field}
                     >
@@ -418,6 +434,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                     <Input
                       type="date"
                       min={format(new Date(), 'yyyy-MM-dd')}
+                      className="h-11"
                       disabled={isSubmitting}
                       {...field}
                     />
@@ -441,6 +458,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                         placeholder="1"
                         min="0"
                         step="0.01"
+                        className="h-11"
                         disabled={isSubmitting}
                         {...field}
                         value={field.value ?? ''}
@@ -480,7 +498,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                     <FormLabel>Unità</FormLabel>
                     <FormControl>
                       <select
-                        className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                        className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                         disabled={isSubmitting}
                         value={field.value || ''}
                         onChange={(e) => {
@@ -575,7 +593,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                 variant="outline"
                 onClick={onCancel}
                 disabled={isSubmitting}
-                className="flex-1"
+                className="h-11 flex-1"
               >
                 Annulla
               </Button>
@@ -583,7 +601,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
             <Button
               type="submit"
               disabled={isSubmitting}
-              className="flex-1"
+              className="h-11 flex-1"
             >
               {getSubmitButtonText(mode, isSubmitting)}
             </Button>

--- a/src/components/foods/FoodModals.tsx
+++ b/src/components/foods/FoodModals.tsx
@@ -21,8 +21,9 @@ import type { FoodFormData } from '@/lib/validations/food.schemas'
 const FoodForm = lazy(() => import('./FoodForm').then(m => ({ default: m.FoodForm })))
 
 const FormSpinner = () => (
-  <div className="flex justify-center py-8">
-    <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
+  <div className="flex justify-center py-8" role="status" aria-live="polite">
+    <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" aria-hidden="true" />
+    <span className="sr-only">Caricamento modulo...</span>
   </div>
 )
 

--- a/src/components/foods/ImageUpload.tsx
+++ b/src/components/foods/ImageUpload.tsx
@@ -135,26 +135,26 @@ export function ImageUpload({ value, onChange, disabled = false }: ImageUploadPr
     <div className="space-y-2">
       {/* Preview or Upload Button */}
       {displayPreview || isLoadingPreview || isConverting ? (
-        <div className="relative group">
+        <div className="relative">
           {/* Image Preview */}
-          <div className="relative w-full h-48 rounded-lg overflow-hidden border border-gray-200 bg-gray-50">
+          <div className="relative w-full h-48 rounded-lg overflow-hidden border border-border bg-muted">
             {isLoadingPreview ? (
-              <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+              <div className="absolute inset-0 bg-black/50 flex items-center justify-center" role="status" aria-live="polite">
                 <div className="text-white text-center">
-                  <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" />
+                  <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" aria-hidden="true" />
                   <p className="text-sm">Caricamento immagine...</p>
                 </div>
               </div>
             ) : isConverting ? (
-              <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+              <div className="absolute inset-0 bg-black/50 flex items-center justify-center" role="status" aria-live="polite">
                 <div className="text-white text-center">
-                  <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" />
+                  <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" aria-hidden="true" />
                   <p className="text-sm">Conversione immagine HEIC...</p>
                 </div>
               </div>
             ) : signedUrlError ? (
-              <div className="w-full h-full flex flex-col items-center justify-center text-gray-400">
-                <ImageIcon className="w-12 h-12 mb-2" />
+              <div className="w-full h-full flex flex-col items-center justify-center text-muted-foreground">
+                <ImageIcon className="w-12 h-12 mb-2" aria-hidden="true" />
                 <span className="text-xs">Errore caricamento</span>
               </div>
             ) : displayPreview ? (
@@ -167,13 +167,13 @@ export function ImageUpload({ value, onChange, disabled = false }: ImageUploadPr
             ) : null}
           </div>
 
-          {/* Remove Button */}
+          {/* Remove Button — always visible (touch devices have no hover) */}
           {!disabled && !isLoadingPreview && !isConverting && (
             <Button
               type="button"
               variant="destructive"
               size="sm"
-              className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+              className="absolute top-2 right-2 min-h-[44px] shadow-md"
               onClick={handleRemove}
               aria-label="Rimuovi immagine"
             >
@@ -195,10 +195,10 @@ export function ImageUpload({ value, onChange, disabled = false }: ImageUploadPr
               disabled={disabled || isConverting}
               aria-label="Scatta foto con fotocamera"
             >
-              <Camera className="w-6 h-6 text-gray-400" aria-hidden="true" />
+              <Camera className="w-6 h-6 text-muted-foreground" aria-hidden="true" />
               <div className="text-center">
                 <div className="text-sm font-medium">Fotocamera</div>
-                <p className="text-xs text-gray-500 mt-1">Scatta foto</p>
+                <p className="text-xs text-muted-foreground mt-1">Scatta foto</p>
               </div>
             </Button>
 
@@ -211,10 +211,10 @@ export function ImageUpload({ value, onChange, disabled = false }: ImageUploadPr
               disabled={disabled || isConverting}
               aria-label="Scegli foto dalla galleria"
             >
-              <Upload className="w-6 h-6 text-gray-400" aria-hidden="true" />
+              <Upload className="w-6 h-6 text-muted-foreground" aria-hidden="true" />
               <div className="text-center">
                 <div className="text-sm font-medium">Galleria</div>
-                <p className="text-xs text-gray-500 mt-1">Scegli foto</p>
+                <p className="text-xs text-muted-foreground mt-1">Scegli foto</p>
               </div>
             </Button>
           </div>
@@ -247,7 +247,7 @@ export function ImageUpload({ value, onChange, disabled = false }: ImageUploadPr
       {/* Error Message */}
       {error && (
         <div
-          className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md px-3 py-2"
+          className="text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2"
           role="alert"
         >
           {error}
@@ -256,7 +256,7 @@ export function ImageUpload({ value, onChange, disabled = false }: ImageUploadPr
 
       {/* Help Text */}
       {!displayPreview && !error && !isLoadingPreview && !isConverting && (
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-muted-foreground">
           L'immagine verrà automaticamente compressa e ridimensionata.
           Le foto iPhone (HEIC) vengono convertite in JPEG.
         </p>

--- a/src/components/foods/__tests__/FoodForm.test.tsx
+++ b/src/components/foods/__tests__/FoodForm.test.tsx
@@ -108,6 +108,27 @@ describe('FoodForm accordion sections', () => {
     expect(detailsButton.className).not.toMatch(/bg-primary/)
   })
 
+  it('barcode button accessible name contains its visible label (WCAG 2.5.3)', () => {
+    render(<FoodForm mode="create" onSubmit={mockOnSubmit} />)
+
+    // The button must be findable by its visible text, with no overriding
+    // aria-label that hides "Scansiona Barcode" from voice-control users.
+    const scanButton = screen.getByRole('button', { name: /Scansiona Barcode/i })
+    expect(scanButton).toBeInTheDocument()
+    expect(scanButton).not.toHaveAttribute('aria-label')
+  })
+
+  it('renders form controls with a >=44px touch target height', () => {
+    render(<FoodForm mode="create" onSubmit={mockOnSubmit} />)
+
+    // Name input and the submit button should carry the 44px height class.
+    const nameInput = screen.getByPlaceholderText('es. Latte intero')
+    expect(nameInput.className).toMatch(/h-11/)
+
+    const submit = screen.getByRole('button', { name: /Aggiungi alimento/i })
+    expect(submit.className).toMatch(/h-11/)
+  })
+
   it('should keep main section open after barcode scan populates notes', async () => {
     const user = userEvent.setup()
 
@@ -128,7 +149,7 @@ describe('FoodForm accordion sections', () => {
     render(<FoodForm mode="create" onSubmit={mockOnSubmit} />)
 
     // Open the barcode scanner by clicking the scan button
-    const scanButtons = screen.getAllByLabelText('Apri scanner barcode per compilare automaticamente i dati')
+    const scanButtons = screen.getAllByRole('button', { name: /Scansiona Barcode/i })
     await user.click(scanButtons[0])
 
     // Wait for lazy-loaded BarcodeScanner mock to render via Suspense

--- a/src/components/foods/__tests__/ImageUpload.test.tsx
+++ b/src/components/foods/__tests__/ImageUpload.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom/vitest'
+import { ImageUpload } from '../ImageUpload'
+
+// A signed URL is needed so the preview (and its Remove button) renders.
+vi.mock('@/hooks/useSignedUrl', () => ({
+  useSignedUrl: (path: string | null) => ({
+    signedUrl: path ? 'https://example.test/signed.jpg' : null,
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+afterEach(() => cleanup())
+
+describe('ImageUpload — remove affordance (touch)', () => {
+  it('shows the Rimuovi button without relying on hover, and removes on click', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<ImageUpload value="foods/existing.jpg" onChange={onChange} />)
+
+    const removeBtn = screen.getByRole('button', { name: /Rimuovi immagine/i })
+    expect(removeBtn).toBeInTheDocument()
+    // Must NOT be hover-gated: touch devices have no hover state.
+    expect(removeBtn.className).not.toMatch(/opacity-0/)
+    expect(removeBtn.className).not.toMatch(/group-hover/)
+    // Comfortable touch target.
+    expect(removeBtn.className).toMatch(/min-h-\[44px\]/)
+
+    await user.click(removeBtn)
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('renders camera and gallery choices in the empty state', () => {
+    render(<ImageUpload value={null} onChange={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /Scatta foto con fotocamera/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Scegli foto dalla galleria/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Impeccable 2 — Aggiungi/Modifica alimento (Fase B)

Chiude la revisione dell'unità #16 (form, foto, barcode). Fase A: audit 15/20, critique 33/40, detect 0/41.

### Fix applicati (P1 + tutti i P2)
| | Finding | File |
|---|---|---|
| **P1-A** | Tokenizzati i colori grezzi di `ImageUpload` (gray/red → `muted`/`border`/`destructive`): anteprima, box errore e help text seguono ora il tema scuro | `ImageUpload.tsx` |
| **P1-B** | Pulsante "Rimuovi" foto sempre visibile su touch (rimosso `opacity-0 group-hover`), area ≥44px | `ImageUpload.tsx` |
| **P2-A** | Banner "alimento modificato" su token `--warning` invece di `orange-*` | `FoodForm.tsx` |
| **P2-B** | Stati successo/attività scanner su `--success`/`--primary` invece di `green-500` | `BarcodeScanner.tsx` |
| **P2-C** | `localizeScanError()`: errori fotocamera ("Not supported", permesso negato, fotocamera occupata) mappati in italiano con indicazioni | `BarcodeScanner.tsx` |
| **P2-D** | Controlli e azioni del form a 44px (`h-11`): input, 3 select, data, Annulla/Aggiungi, pulsante barcode | `FoodForm.tsx` |
| **P2-E** | Stati di caricamento annunciati (`role=status`/`aria-live`): overlay ImageUpload/scanner, fallback Suspense, spinner form | tutti |
| **P2-F** | `onCancel` spostato in un ref → l'effetto di conflict-detection non ri-sottoscrive il canale realtime a ogni render | `FoodForm.tsx` |
| **P2-G** | Rimosso l'`aria-label` ridondante dal pulsante barcode: il nome accessibile contiene ora il testo visibile (**WCAG 2.5.3 Label in Name**, Liv. A) | `FoodForm.tsx` |

### Rinviati (con motivazione)
- **P3-A toast blu "Tip: Fai swipe…"** e **P3-B close del Dialog "Close" in inglese**: cross-cutting (Toaster globale / default shadcn) → consolidamento nell'unità #23, fuori scope #16 (change-tracing).
- **P3-C highlight verde sulla sezione accordion chiusa**: micro-aesthetic, non tematicamente urgente.

### Re-assessment pre → post
| | Pre | Post | Δ |
|---|---|---|---|
| Detect | 0/41 | 0/41 | — |
| **Audit** | **15/20** | **19/20** | **+4** |
| **Critique** | **33/40** | **37/40** | **+4** |

**Audit per dimensione**: theming 2→4, accessibilità 3→4, responsive 3→4, anti-pattern 4→4, performance 3→3 (churn realtime risolto; render non profilato).
**Critique per euristica**: Visibility 3→4 (loading annunciati), User Control 3→4 (rimuovi-foto su touch), Consistency 3→4 (colori tokenizzati + nome barcode), Error Recovery 3→4 ("Not supported"→IT).

### Verifica
`tsc` ok · **47/47 test** (8 nuovi/aggiornati) · detect 0/41 · screenshot mobile light+dark `docs/development/screenshots/foodform/` (pre) e `/after` (post) · `code-simplifier` eseguito (nessuna semplificazione necessaria, diff già tracciato).

Closes #16
