### PR TITLE
feat: uniforma navigazione, tema e guida (accessibilità + token)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ docs/superpowers/
 
 # Impeccable: PRODUCT.md resta interno (strategia/brand). DESIGN.md invece è pubblico.
 PRODUCT.md
+
+# Impeccable: snapshot critique interni (rigenerabili, findings già pubblici nelle issue)
+.impeccable/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - Form "Aggiungi/Modifica alimento": campi (nome, categoria, posizione, data, quantità) e pulsanti principali portati a un'area tattile di almeno 44px, più comoda da toccare con una mano.
 - Vista calendario ridisegnata ad agenda verticale: ora vedi l'intera settimana a colpo d'occhio in un'unica schermata, scorrendo in verticale, invece di scorrere di lato tra colonne quasi vuote. Ogni giorno mostra "Oggi"/"Domani", il numero di alimenti in scadenza e l'urgenza (oggi evidenziato in rosso, i giorni successivi in ambra).
 - Filtri e ricerca allineati all'identità verde del brand: il contatore dei filtri attivi usa ora il verde invece del blu; il campo di ricerca e i menu dei filtri sono portati a un'area tattile di almeno 44px, e l'etichetta "Cancella" è visibile anche su smartphone.
+- Intestazione dell'app uniformata: le icone di guida, tema e account hanno ora lo stesso stile (rimosso l'accento verde isolato sull'icona account) e un'area tattile di almeno 44px; la descrizione sotto il logo è in italiano ("Scadenze sotto controllo").
 
 ### Fixed
 - Accessibilità dei moduli di autenticazione: il pulsante mostra/nascondi password è ora raggiungibile da tastiera e annunciato dagli screen reader, i titoli di pagina sono heading semantici (`<h1>`) e gli stati di caricamento vengono annunciati.
@@ -30,8 +31,11 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - Accessibilità del form alimento: gli stati di caricamento (scanner, conversione foto, salvataggio) sono annunciati agli screen reader e il pulsante "Scansiona Barcode" è identificabile dal suo testo visibile, utile per i comandi vocali.
 - Vista calendario: gli alimenti sono ora raggiungibili e apribili da tastiera (prima erano selezionabili solo con tocco o mouse), con area tattile di almeno 44px e struttura per giorno leggibile dagli screen reader.
 - Coerenza in tema scuro dello sfondo che appare facendo swipe sulle card (verde "modifica" / rosso "elimina"): ora usa i colori del tema invece di tinte fisse.
-
-## [1.6.3] - 2026-05-17
+- Guida rapida: la voce sullo stato di scadenza ora spiega che ogni alimento mostra i giorni mancanti e un'etichetta colorata (verde oltre una settimana, ambra negli ultimi 7 giorni, rossa alla scadenza e dopo), invece di elencare colori che non corrispondevano all'app e che escludevano chi non distingue bene le tinte.
+- Selettore del tema (Chiaro / Scuro / Sistema): l'opzione attiva è ora annunciata correttamente agli screen reader.
+- Schermata di caricamento a tutta pagina: ora viene annunciata agli screen reader e rispetta la preferenza di sistema "riduci animazioni".
+- Link legali nel footer (Privacy, Termini, Cookie): area tattile più ampia su smartphone e indicazione, per gli screen reader, che si aprono in una nuova scheda.
+- Pulsante di disconnessione nel menu account: usa ora il colore di pericolo del tema, leggibile anche in tema scuro.
 
 ### Security
 - Patch vulnerabilità `vite` (≤ 6.4.1): Arbitrary File Read via Dev Server WebSocket ([GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583), High) e Path Traversal in Optimized Deps `.map` Handling ([GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9), Moderate) — bump a `^6.4.2`

--- a/src/components/guide/QuickGuideDialog.tsx
+++ b/src/components/guide/QuickGuideDialog.tsx
@@ -35,8 +35,8 @@ const guideItems = [
   },
   {
     icon: Palette,
-    title: 'Colori scadenza',
-    description: 'Verde (7+ gg), Giallo (4-7), Arancione (1-3), Rosso (scaduto)',
+    title: 'Stato di scadenza',
+    description: 'Ogni alimento mostra i giorni che mancano e un’etichetta colorata: verde finché manca più di una settimana, ambra negli ultimi 7 giorni, rossa il giorno della scadenza e quando è già scaduto',
   },
   {
     icon: Search,
@@ -72,7 +72,7 @@ export function QuickGuideDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="ghost" className="h-10 w-10 p-0" aria-label="Guida rapida">
+        <Button variant="ghost" className="h-11 w-11 p-0" aria-label="Guida rapida">
           <CircleHelp className="!h-7 !w-7" />
         </Button>
       </DialogTrigger>

--- a/src/components/guide/__tests__/QuickGuideDialog.test.tsx
+++ b/src/components/guide/__tests__/QuickGuideDialog.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QuickGuideDialog } from '../QuickGuideDialog'
+
+afterEach(cleanup)
+
+function renderGuide() {
+  return render(
+    <MemoryRouter>
+      <QuickGuideDialog />
+    </MemoryRouter>
+  )
+}
+
+describe('QuickGuideDialog — stato di scadenza', () => {
+  it('descrive lo stato con segnali non solo cromatici (giorni + etichetta)', async () => {
+    const user = userEvent.setup()
+    renderGuide()
+    await user.click(screen.getByRole('button', { name: 'Guida rapida' }))
+
+    const dialog = await screen.findByRole('dialog')
+    // menziona i giorni mancanti, non solo i colori
+    expect(dialog.textContent).toMatch(/giorni/i)
+    expect(dialog.textContent).toMatch(/etichetta/i)
+  })
+
+  it('non descrive tier di colore inesistenti (Giallo 4-7 / Arancione 1-3)', async () => {
+    const user = userEvent.setup()
+    renderGuide()
+    await user.click(screen.getByRole('button', { name: 'Guida rapida' }))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog.textContent).not.toMatch(/Giallo/i)
+    expect(dialog.textContent).not.toMatch(/Arancione/i)
+  })
+})

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -75,10 +75,10 @@ export function AppLayout() {
         <div className="container flex h-16 items-center justify-between px-4">
           {/* Logo / Brand */}
           <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
-            <AppIcon size={40} className="rounded-lg" aria-label="Logo entro" />
+            <AppIcon size={40} className="rounded-lg" />
             <div>
               <div className="text-lg font-bold text-foreground">entro</div>
-              <p className="text-xs text-muted-foreground">Food Expiry Tracker</p>
+              <p className="text-xs text-muted-foreground">Scadenze sotto controllo</p>
             </div>
           </Link>
 
@@ -92,10 +92,10 @@ export function AppLayout() {
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="ghost"
-                  className="h-10 w-10 rounded-full p-0"
+                  className="h-11 w-11 rounded-full p-0"
                   aria-label="Menu utente"
                 >
-                  <User className="!h-7 !w-7 text-primary" />
+                  <User className="!h-7 !w-7" />
                 </Button>
               </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-56">
@@ -124,7 +124,7 @@ export function AppLayout() {
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={handleLogout}
-                className="cursor-pointer text-red-600 focus:text-red-600"
+                className="cursor-pointer text-destructive focus:text-destructive"
               >
                 <LogOut className="mr-2 h-4 w-4" />
                 <span>Disconnetti</span>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,32 +7,35 @@
 export function Footer() {
   return (
     <footer className="mt-8 py-4 border-t">
-      <div className="flex flex-wrap justify-center gap-4 text-sm text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-center gap-x-2 text-sm text-muted-foreground">
         <a
           href="https://app.legalblink.it/api/documents/697e24efc95cff002359012c/privacy-policy-per-siti-web-o-e-commerce-it"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-foreground hover:underline transition-colors"
+          className="inline-flex min-h-11 items-center px-2 hover:text-foreground hover:underline transition-colors"
         >
           Privacy Policy
+          <span className="sr-only"> (si apre in una nuova scheda)</span>
         </a>
-        <span className="text-muted-foreground/50">•</span>
+        <span aria-hidden="true" className="text-muted-foreground/50">•</span>
         <a
           href="https://app.legalblink.it/api/documents/697e24efc95cff002359012c/condizioni-d'uso-del-sito-it"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-foreground hover:underline transition-colors"
+          className="inline-flex min-h-11 items-center px-2 hover:text-foreground hover:underline transition-colors"
         >
           Termini e Condizioni
+          <span className="sr-only"> (si apre in una nuova scheda)</span>
         </a>
-        <span className="text-muted-foreground/50">•</span>
+        <span aria-hidden="true" className="text-muted-foreground/50">•</span>
         <a
           href="https://app.legalblink.it/api/documents/697e24efc95cff002359012c/cookie-policy-it"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-foreground hover:underline transition-colors"
+          className="inline-flex min-h-11 items-center px-2 hover:text-foreground hover:underline transition-colors"
         >
           Cookie Policy
+          <span className="sr-only"> (si apre in una nuova scheda)</span>
         </a>
       </div>
     </footer>

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -4,13 +4,15 @@ import { Button } from '../ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
 
 /**
  * Theme Toggle Component
- * Dropdown menu to switch between light, dark, and system themes
+ * Dropdown menu to switch between light, dark, and system themes.
+ * Uses a radio group so the current theme is announced to screen readers.
  */
 export function ThemeToggle() {
   const { theme, setTheme, effectiveTheme } = useTheme()
@@ -18,7 +20,7 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="h-10 w-10 p-0">
+        <Button variant="ghost" className="h-11 w-11 p-0">
           {effectiveTheme === 'dark' ? (
             <Moon className="!h-7 !w-7" />
           ) : (
@@ -28,36 +30,23 @@ export function ThemeToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() => setTheme('light')}
-          className="cursor-pointer"
+        <DropdownMenuRadioGroup
+          value={theme}
+          onValueChange={(value) => setTheme(value as 'light' | 'dark' | 'system')}
         >
-          <Sun className="mr-2 h-4 w-4" />
-          <span>Chiaro</span>
-          {theme === 'light' && (
-            <span className="ml-auto text-xs text-primary">✓</span>
-          )}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => setTheme('dark')}
-          className="cursor-pointer"
-        >
-          <Moon className="mr-2 h-4 w-4" />
-          <span>Scuro</span>
-          {theme === 'dark' && (
-            <span className="ml-auto text-xs text-primary">✓</span>
-          )}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => setTheme('system')}
-          className="cursor-pointer"
-        >
-          <Monitor className="mr-2 h-4 w-4" />
-          <span>Sistema</span>
-          {theme === 'system' && (
-            <span className="ml-auto text-xs text-primary">✓</span>
-          )}
-        </DropdownMenuItem>
+          <DropdownMenuRadioItem value="light" className="cursor-pointer">
+            <Sun className="mr-2 h-4 w-4" />
+            <span>Chiaro</span>
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="dark" className="cursor-pointer">
+            <Moon className="mr-2 h-4 w-4" />
+            <span>Scuro</span>
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="system" className="cursor-pointer">
+            <Monitor className="mr-2 h-4 w-4" />
+            <span>Sistema</span>
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import { Footer } from '../Footer'
+
+afterEach(cleanup)
+
+describe('Footer', () => {
+  it('mostra i tre link legali raggiungibili', () => {
+    render(<Footer />)
+    expect(screen.getByRole('link', { name: /Privacy Policy/ })).toBeTruthy()
+    expect(screen.getByRole('link', { name: /Termini e Condizioni/ })).toBeTruthy()
+    expect(screen.getByRole('link', { name: /Cookie Policy/ })).toBeTruthy()
+  })
+
+  it('apre i link in una nuova scheda in modo sicuro e annunciato', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: /Privacy Policy/ })
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+    // l'apertura in nuova scheda è annunciata agli screen reader
+    expect(within(link).getByText(/nuova scheda/)).toBeTruthy()
+  })
+
+  it('dà ai link un’area tattile adeguata (≥44px)', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: /Cookie Policy/ })
+    expect(link.className).toMatch(/min-h-11|min-h-\[44px\]/)
+  })
+})

--- a/src/components/layout/__tests__/ThemeToggle.test.tsx
+++ b/src/components/layout/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const { setTheme } = vi.hoisted(() => ({ setTheme: vi.fn() }))
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'dark', setTheme, effectiveTheme: 'dark' }),
+}))
+
+import { ThemeToggle } from '../ThemeToggle'
+
+afterEach(() => {
+  cleanup()
+  setTheme.mockReset()
+})
+
+describe('ThemeToggle', () => {
+  it('espone le opzioni come radio con lo stato corrente annunciato', async () => {
+    const user = userEvent.setup()
+    render(<ThemeToggle />)
+    await user.click(screen.getByRole('button', { name: 'Cambia tema' }))
+
+    const radios = await screen.findAllByRole('menuitemradio')
+    expect(radios).toHaveLength(3)
+
+    const scuro = radios.find((r) => /Scuro/.test(r.textContent || ''))
+    expect(scuro?.getAttribute('aria-checked')).toBe('true')
+
+    const chiaro = radios.find((r) => /Chiaro/.test(r.textContent || ''))
+    expect(chiaro?.getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('non usa il glifo ✓ per indicare la selezione', async () => {
+    const user = userEvent.setup()
+    render(<ThemeToggle />)
+    await user.click(screen.getByRole('button', { name: 'Cambia tema' }))
+    await screen.findAllByRole('menuitemradio')
+    expect(document.body.textContent).not.toContain('✓')
+  })
+
+  it('cambia tema alla selezione di un’opzione', async () => {
+    const user = userEvent.setup()
+    render(<ThemeToggle />)
+    await user.click(screen.getByRole('button', { name: 'Cambia tema' }))
+    const radios = await screen.findAllByRole('menuitemradio')
+    const chiaro = radios.find((r) => /Chiaro/.test(r.textContent || ''))!
+    await user.click(chiaro)
+    expect(setTheme).toHaveBeenCalledWith('light')
+  })
+})

--- a/src/components/ui/PageLoader.tsx
+++ b/src/components/ui/PageLoader.tsx
@@ -4,9 +4,13 @@
  */
 export function PageLoader() {
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center justify-center min-h-screen"
+    >
       <div className="flex flex-col items-center gap-3">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary"></div>
+        <div className="h-8 w-8 animate-spin motion-reduce:animate-none rounded-full border-4 border-border border-t-primary"></div>
         <div className="text-muted-foreground">Caricamento...</div>
       </div>
     </div>

--- a/src/components/ui/__tests__/PageLoader.test.tsx
+++ b/src/components/ui/__tests__/PageLoader.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { PageLoader } from '../PageLoader'
+
+afterEach(cleanup)
+
+describe('PageLoader', () => {
+  it('expone lo stato di caricamento agli screen reader', () => {
+    render(<PageLoader />)
+    const status = screen.getByRole('status')
+    expect(status).toBeTruthy()
+    expect(status.getAttribute('aria-live')).toBe('polite')
+    expect(status.textContent).toContain('Caricamento')
+  })
+
+  it('disattiva l’animazione con prefers-reduced-motion', () => {
+    const { container } = render(<PageLoader />)
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).toBeTruthy()
+    expect(spinner?.className).toContain('motion-reduce:animate-none')
+  })
+})


### PR DESCRIPTION
## Impeccable #18 — Navigazione, layout & tema (Fase B)

Superficie mista (header protetto + footer pubblico). Scope concordato con priorità utente: **tutti i findings P1+P2+P3**, tagline **italianizzata**, icone header **tutte neutre**.

### Re-assessment pre → post
- **Audit: 15 → 19/20** (a11y 2→4, responsive 3→4, theming 3→4, perf 3→3, anti 4→4)
- **Critique: 31 → 36/40** (Visibility 3→4, Match 3→4, Consistency 2→4, Aesthetic 3→4)
- **Detect deterministico: 0/41**

### Cosa cambia

**P1 — Guida accessibile e corretta** (`QuickGuideDialog`)
La voce "Colori scadenza" insegnava lo stato **solo col colore** ed elencava **4 tier inesistenti** ("Giallo 4-7", "Arancione 1-3"). Verificato `FoodCard.getExpiryStatus`: i tier reali sono **3** (verde >7gg, ambra 1-7gg banda unica, rosso oggi/scaduto), sempre con testo + bordo + `aria-label`. Riscritta come "Stato di scadenza" su giorni mancanti + etichetta colorata, allineata all'implementazione.

**P2 — Accessibilità & coerenza**
- `ThemeToggle` refactor a `DropdownMenuRadioGroup`/`RadioItem`: `role=menuitemradio` + `aria-checked`, il tema attivo è ora annunciato agli screen reader (rimosso il glifo `✓` solo grafico).
- Header uniformato: icone guida/tema/account stesso trattamento (icona account non più `text-primary` verde isolato), tutte portate a **≥44px**; logout su token `text-destructive` (prima `text-red-600` grezzo).
- `PageLoader`: `role="status"` + `aria-live="polite"` + `motion-reduce:animate-none`.

**P3 — Rifiniture**
- Tagline header "Food Expiry Tracker" → **"Scadenze sotto controllo"** (italiano).
- Rimossa prop `aria-label` morta su `<AppIcon>` (l'SVG è `aria-hidden`; il nome accessibile arriva dal testo adiacente).
- Link legali `Footer`: area tattile ≥44px + indicazione "(si apre in una nuova scheda)" per gli screen reader.

> Nota: i colori del logo `AppIcon` (`white`/`#22c55e`/`#166534`) sono **lasciati di proposito** — asset di brand; tokenizzare il bianco romperebbe il quadrante in tema scuro.

### Test & verifica
- **+10 test** (`PageLoader`, `Footer`, `QuickGuideDialog`, `ThemeToggle`) — **76/76 verdi**.
- `tsc --noEmit` pulito · detect 0/41 · code-simplifier (Agent): nessuna semplificazione (diff già pulito).
- Verifica mobile 414×896 (light + dark) su header, menu tema, dialog guida, footer.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)