### PR TITLE
feat(impeccable): coda #34 — 6 item residui (perf, a11y, micro-UI, tech-debt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Changed
+- Form "Aggiungi/Modifica alimento": la sezione richiudibile "Dettagli aggiuntivi", quando è chiusa, mostra ora uno sfondo neutro invece di una leggera velatura verde — il verde resta riservato agli elementi attivi dell'identità dell'app.
+- Liste di alimenti più leggere su smartphone: il rilevamento del dispositivo touch è ora condiviso da tutte le card con un'unica sottoscrizione, invece di registrarne una per ogni card della lista.
+
+### Fixed
+- Eliminazione account: con una dispensa vuota (0 alimenti) la finestra non ripete più il conteggio degli alimenti a ogni apertura.
+
 ## [1.7.1] - 2026-06-11
 
 ### Security

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -309,7 +309,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
             onClick={() => setOpenSection('main')}
             className={cn(
               'flex w-full items-center gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md p-2 -mx-2',
-              openSection !== 'main' && 'bg-primary/10 dark:bg-primary/15'
+              openSection !== 'main' && 'bg-muted/50'
             )}
             aria-expanded={openSection === 'main'}
             aria-controls="section-main"
@@ -528,7 +528,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
             onClick={() => setOpenSection('details')}
             className={cn(
               'flex w-full items-center gap-2 text-left border-t pt-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md px-2 pb-2 -mx-2',
-              openSection !== 'details' && 'bg-primary/10 dark:bg-primary/15'
+              openSection !== 'details' && 'bg-muted/50'
             )}
             aria-expanded={openSection === 'details'}
             aria-controls="section-details"

--- a/src/components/foods/SwipeableCard.tsx
+++ b/src/components/foods/SwipeableCard.tsx
@@ -3,6 +3,7 @@ import { useSwipeable } from 'react-swipeable'
 import { Edit, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { triggerHaptic } from '@/lib/haptics'
+import { useIsMobile } from '@/hooks/useIsMobile'
 
 interface SwipeableCardProps {
   children: React.ReactNode
@@ -23,26 +24,13 @@ interface SwipeableCardProps {
  * - Works on iOS and Android
  */
 export function SwipeableCard({ children, onEdit, onDelete, className, showHintAnimation = false }: SwipeableCardProps) {
-  const [isMobile, setIsMobile] = useState(false)
+  const isMobile = useIsMobile()
   const [swipeOffset, setSwipeOffset] = useState(0)
   const [isAnimating, setIsAnimating] = useState(false)
   const cardRef = useRef<HTMLDivElement>(null)
   const thresholdTriggered = useRef(false)
 
   const HINT_ANIMATION_KEY = 'entro_hasSeenSwipeAnimation'
-
-  // Detect if device is touch-enabled (mobile)
-  useEffect(() => {
-    const checkMobile = () => {
-      const hasTouchScreen = 'ontouchstart' in window || navigator.maxTouchPoints > 0
-      const isMobileWidth = window.innerWidth < 768
-      setIsMobile(hasTouchScreen && isMobileWidth)
-    }
-
-    checkMobile()
-    window.addEventListener('resize', checkMobile)
-    return () => window.removeEventListener('resize', checkMobile)
-  }, [])
 
   // Animated hint: mini-swipe demonstration on first card (first time only)
   useEffect(() => {

--- a/src/components/foods/__tests__/FoodForm.test.tsx
+++ b/src/components/foods/__tests__/FoodForm.test.tsx
@@ -83,10 +83,11 @@ describe('FoodForm accordion sections', () => {
     const mainButton = document.querySelector('button[aria-controls="section-main"]')!
     const detailsButton = document.querySelector('button[aria-controls="section-details"]')!
 
-    // Closed section (details) should have background class
-    expect(detailsButton.className).toMatch(/bg-primary/)
+    // Closed section (details) gets a neutral highlight, not the brand green
+    expect(detailsButton.className).toMatch(/bg-muted/)
+    expect(detailsButton.className).not.toMatch(/bg-primary/)
     // Open section (main) should NOT have the closed background class
-    expect(mainButton.className).not.toMatch(/bg-primary/)
+    expect(mainButton.className).not.toMatch(/bg-muted/)
   })
 
   it('should swap background class when toggling sections', async () => {
@@ -96,16 +97,16 @@ describe('FoodForm accordion sections', () => {
     const mainButton = document.querySelector('button[aria-controls="section-main"]')!
     const detailsButton = document.querySelector('button[aria-controls="section-details"]')!
 
-    // Initially: main open (no bg), details closed (bg)
-    expect(mainButton.className).not.toMatch(/bg-primary/)
-    expect(detailsButton.className).toMatch(/bg-primary/)
+    // Initially: main open (no bg), details closed (neutral bg)
+    expect(mainButton.className).not.toMatch(/bg-muted/)
+    expect(detailsButton.className).toMatch(/bg-muted/)
 
     // Click details to open it (closes main)
     await user.click(detailsButton)
 
-    // Now: main closed (bg), details open (no bg)
-    expect(mainButton.className).toMatch(/bg-primary/)
-    expect(detailsButton.className).not.toMatch(/bg-primary/)
+    // Now: main closed (neutral bg), details open (no bg)
+    expect(mainButton.className).toMatch(/bg-muted/)
+    expect(detailsButton.className).not.toMatch(/bg-muted/)
   })
 
   it('barcode button accessible name contains its visible label (WCAG 2.5.3)', () => {

--- a/src/components/settings/DeleteAccountDialog.tsx
+++ b/src/components/settings/DeleteAccountDialog.tsx
@@ -20,6 +20,7 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { triggerHaptic } from '@/lib/haptics'
+import { inlineErrorAttrs } from '@/lib/a11y'
 
 /**
  * Delete Account Dialog Component
@@ -48,7 +49,9 @@ export function DeleteAccountDialog() {
   const handleOpenChange = async (isOpen: boolean) => {
     setOpen(isOpen)
 
-    if (isOpen && !foodCount) {
+    // `foodCount === null` e non `!foodCount`: con un totale reale di 0 alimenti
+    // `!foodCount` resta truthy → la query veniva rifatta a ogni riapertura del dialog.
+    if (isOpen && foodCount === null) {
       // Fetch food count
       const { count } = await supabase
         .from('foods')
@@ -239,8 +242,7 @@ export function DeleteAccountDialog() {
             }}
             disabled={isDeleting}
             className="h-11"
-            aria-invalid={error ? true : undefined}
-            aria-describedby={error ? 'delete-password-error' : undefined}
+            {...inlineErrorAttrs(!!error, 'delete-password-error')}
           />
           {error && (
             <p id="delete-password-error" role="alert" className="text-sm text-destructive">

--- a/src/components/settings/__tests__/DeleteAccountDialog.test.tsx
+++ b/src/components/settings/__tests__/DeleteAccountDialog.test.tsx
@@ -3,12 +3,13 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-const { signInWithPassword, signOut, rpc, navigateMock, clearAuthStorage } = vi.hoisted(() => ({
+const { signInWithPassword, signOut, rpc, navigateMock, clearAuthStorage, countIs } = vi.hoisted(() => ({
   signInWithPassword: vi.fn(),
   signOut: vi.fn(() => Promise.resolve({ error: null })),
   rpc: vi.fn(() => Promise.resolve({ error: null })),
   navigateMock: vi.fn(),
   clearAuthStorage: vi.fn(),
+  countIs: vi.fn(() => Promise.resolve({ count: 4 })),
 }))
 
 vi.mock('react-router-dom', () => ({ useNavigate: () => navigateMock }))
@@ -20,7 +21,7 @@ vi.mock('@/lib/supabase', () => ({
   supabase: {
     from: () => ({
       select: () => ({
-        is: () => Promise.resolve({ count: 4 }),
+        is: countIs,
         eq: () => ({ not: () => Promise.resolve({ data: [] }) }),
       }),
     }),
@@ -94,5 +95,26 @@ describe('DeleteAccountDialog — salvaguardie azione distruttiva', () => {
     const input = screen.getByPlaceholderText('Inserisci password')
     expect(input.getAttribute('aria-invalid')).toBe('true')
     expect(input.getAttribute('aria-describedby')).toBe('delete-password-error')
+  })
+
+  it('con 0 alimenti non rifà la fetch del conteggio alla riapertura del dialog', async () => {
+    // Con un totale reale di 0, il vecchio guard `!foodCount` rifaceva la query
+    // a ogni apertura. Con `foodCount === null` la fetch parte una volta sola.
+    countIs.mockResolvedValue({ count: 0 })
+    const user = setup()
+    render(<DeleteAccountDialog />)
+
+    // Prima apertura → parte la fetch, il conteggio (0) viene mostrato
+    await openDialog(user)
+    await screen.findByText(/0 totali/)
+    expect(countIs).toHaveBeenCalledTimes(1)
+
+    // Chiudi e riapri
+    await user.click(screen.getByRole('button', { name: 'Annulla' }))
+    await user.click(screen.getByRole('button', { name: 'Elimina account' }))
+    await screen.findByPlaceholderText('Inserisci password')
+
+    // Nessuna nuova fetch: il conteggio 0 è già in stato (non più null)
+    expect(countIs).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/sharing/AcceptInviteFlowDialog.tsx
+++ b/src/components/sharing/AcceptInviteFlowDialog.tsx
@@ -13,6 +13,7 @@ import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { AcceptInviteDialog } from './AcceptInviteDialog'
 import { validateInvite } from '../../lib/invites'
+import { inlineErrorAttrs } from '@/lib/a11y'
 
 interface AcceptInviteFlowDialogProps {
   open: boolean
@@ -100,8 +101,7 @@ export function AcceptInviteFlowDialog({
                   autoFocus
                   autoComplete="off"
                   inputMode="text"
-                  aria-invalid={error ? true : undefined}
-                  aria-describedby={error ? 'invite-code-error' : 'invite-code-hint'}
+                  {...inlineErrorAttrs(!!error, 'invite-code-error', 'invite-code-hint')}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
                       handleValidate()

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -10,7 +10,7 @@ const AlertDialogTrigger = AlertDialogPrimitive.Trigger
 const AlertDialogPortal = AlertDialogPrimitive.Portal
 
 const AlertDialogOverlay = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
@@ -25,7 +25,7 @@ const AlertDialogOverlay = React.forwardRef<
 AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
 
 const AlertDialogContent = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <AlertDialogPortal>
@@ -71,7 +71,7 @@ const AlertDialogFooter = ({
 AlertDialogFooter.displayName = "AlertDialogFooter"
 
 const AlertDialogTitle = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
@@ -83,7 +83,7 @@ const AlertDialogTitle = React.forwardRef<
 AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
 
 const AlertDialogDescription = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
@@ -96,7 +96,7 @@ AlertDialogDescription.displayName =
   AlertDialogPrimitive.Description.displayName
 
 const AlertDialogAction = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Action>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Action
@@ -111,7 +111,7 @@ const AlertDialogAction = React.forwardRef<
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
 
 const AlertDialogCancel = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Cancel

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -13,7 +13,7 @@ const DialogPortal = DialogPrimitive.Portal
 const DialogClose = DialogPrimitive.Close
 
 const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
@@ -28,7 +28,7 @@ const DialogOverlay = React.forwardRef<
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
@@ -80,7 +80,7 @@ const DialogFooter = ({
 DialogFooter.displayName = "DialogFooter"
 
 const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
@@ -95,7 +95,7 @@ const DialogTitle = React.forwardRef<
 DialogTitle.displayName = DialogPrimitive.Title.displayName
 
 const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -17,7 +17,7 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
 
 const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
     inset?: boolean
   }
@@ -39,7 +39,7 @@ DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName
 
 const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
@@ -55,7 +55,7 @@ DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName
 
 const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
@@ -74,7 +74,7 @@ const DropdownMenuContent = React.forwardRef<
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
 const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean
   }
@@ -92,7 +92,7 @@ const DropdownMenuItem = React.forwardRef<
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
 const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
@@ -116,7 +116,7 @@ DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName
 
 const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.RadioItem
@@ -138,7 +138,7 @@ const DropdownMenuRadioItem = React.forwardRef<
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
 
 const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
     inset?: boolean
   }
@@ -156,7 +156,7 @@ const DropdownMenuLabel = React.forwardRef<
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
 
 const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -87,7 +87,7 @@ const FormItem = React.forwardRef<
 FormItem.displayName = "FormItem"
 
 const FormLabel = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
 >(({ className, ...props }, ref) => {
   const { error, formItemId } = useFormField()
@@ -104,7 +104,7 @@ const FormLabel = React.forwardRef<
 FormLabel.displayName = "FormLabel"
 
 const FormControl = React.forwardRef<
-  React.ElementRef<typeof Slot>,
+  React.ComponentRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
 >(({ ...props }, ref) => {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -9,7 +9,7 @@ const labelVariants = cva(
 )
 
 const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
     VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (

--- a/src/hooks/__tests__/useIsMobile.test.tsx
+++ b/src/hooks/__tests__/useIsMobile.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, act } from '@testing-library/react'
+
+// Fake MediaQueryList controllabile: jsdom non implementa window.matchMedia.
+function createMatchMedia(initialMatches: boolean) {
+  let matches = initialMatches
+  const handlers = new Set<(e: { matches: boolean }) => void>()
+  return {
+    media: '(max-width: 767px)',
+    get matches() {
+      return matches
+    },
+    addEventListener: vi.fn((_type: string, h: (e: { matches: boolean }) => void) => {
+      handlers.add(h)
+    }),
+    removeEventListener: vi.fn((_type: string, h: (e: { matches: boolean }) => void) => {
+      handlers.delete(h)
+    }),
+    // Helper di test: simula un cambio di viewport
+    emit(next: boolean) {
+      matches = next
+      handlers.forEach((h) => h({ matches }))
+    },
+    handlerCount() {
+      return handlers.size
+    },
+  }
+}
+
+let mql: ReturnType<typeof createMatchMedia>
+
+function setTouch(enabled: boolean) {
+  if (enabled) {
+    ;(window as unknown as { ontouchstart: unknown }).ontouchstart = null
+  } else {
+    delete (window as unknown as { ontouchstart?: unknown }).ontouchstart
+  }
+}
+
+function useMatchMedia(matches: boolean, touch: boolean) {
+  setTouch(touch)
+  mql = createMatchMedia(matches)
+  window.matchMedia = vi.fn(() => mql as unknown as MediaQueryList)
+}
+
+// Import dinamico: resetModules() in beforeEach garantisce singleton fresco.
+async function loadHook() {
+  const mod = await import('../useIsMobile')
+  return mod.useIsMobile
+}
+
+function renderProbes(useIsMobile: () => boolean, count = 1) {
+  function Probe({ id }: { id: string }) {
+    const m = useIsMobile()
+    return <span data-testid={id}>{m ? 'mobile' : 'desktop'}</span>
+  }
+  return render(
+    <>
+      {Array.from({ length: count }, (_, i) => (
+        <Probe key={i} id={String.fromCharCode(97 + i)} />
+      ))}
+    </>
+  )
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  cleanup()
+  setTouch(false)
+  vi.restoreAllMocks()
+})
+
+describe('useIsMobile', () => {
+  it('è true solo con touch screen E viewport ≤ 767px', async () => {
+    useMatchMedia(true, true)
+    renderProbes(await loadHook())
+    expect(screen.getByTestId('a').textContent).toBe('mobile')
+  })
+
+  it('è false su touch screen ma viewport desktop (matchMedia non match)', async () => {
+    useMatchMedia(false, true)
+    renderProbes(await loadHook())
+    expect(screen.getByTestId('a').textContent).toBe('desktop')
+  })
+
+  it('è false su viewport stretto ma senza touch (desktop ridotto)', async () => {
+    useMatchMedia(true, false)
+    renderProbes(await loadHook())
+    expect(screen.getByTestId('a').textContent).toBe('desktop')
+  })
+
+  it('reagisce ai cambi di viewport (change event)', async () => {
+    useMatchMedia(false, true)
+    renderProbes(await loadHook())
+    expect(screen.getByTestId('a').textContent).toBe('desktop')
+
+    act(() => mql.emit(true))
+    expect(screen.getByTestId('a').textContent).toBe('mobile')
+  })
+
+  it('monta una sola sottoscrizione anche con N consumer (fix listener per-card)', async () => {
+    useMatchMedia(true, true)
+    renderProbes(await loadHook(), 3)
+
+    // Un solo matchMedia e un solo listener `change` per 3 consumer
+    expect(window.matchMedia).toHaveBeenCalledTimes(1)
+    expect(mql.addEventListener).toHaveBeenCalledTimes(1)
+    expect(mql.handlerCount()).toBe(1)
+  })
+
+  it('rimuove la sottoscrizione quando l’ultimo consumer viene smontato', async () => {
+    useMatchMedia(true, true)
+    const { unmount } = renderProbes(await loadHook(), 2)
+    expect(mql.handlerCount()).toBe(1)
+
+    unmount()
+    expect(mql.handlerCount()).toBe(0)
+    expect(mql.removeEventListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,67 @@
+import { useSyncExternalStore } from 'react'
+
+const MOBILE_QUERY = '(max-width: 767px)'
+
+// Singleton condiviso: una sola `MediaQueryList` e un solo listener `change`
+// per l'intera app, a prescindere da quanti componenti usano l'hook.
+let mediaQuery: MediaQueryList | null = null
+const listeners = new Set<() => void>()
+
+// Ritorna null dove `matchMedia` non esiste (SSR e jsdom nei test): in quel
+// caso l'hook degrada a "non mobile" invece di lanciare.
+function getMediaQuery(): MediaQueryList | null {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return null
+  }
+  if (!mediaQuery) {
+    mediaQuery = window.matchMedia(MOBILE_QUERY)
+  }
+  return mediaQuery
+}
+
+function notify() {
+  for (const listener of listeners) listener()
+}
+
+// Si attacca al primo subscriber e si stacca all'ultimo unmount: con N
+// consumer monta comunque un solo `change` listener (a differenza del
+// precedente `resize` listener per-card in SwipeableCard).
+function subscribe(onStoreChange: () => void): () => void {
+  const mql = getMediaQuery()
+  if (!mql) return () => {}
+  if (listeners.size === 0) {
+    mql.addEventListener('change', notify)
+  }
+  listeners.add(onStoreChange)
+
+  return () => {
+    listeners.delete(onStoreChange)
+    if (listeners.size === 0) {
+      mql.removeEventListener('change', notify)
+    }
+  }
+}
+
+function hasTouchScreen(): boolean {
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0
+}
+
+function getSnapshot(): boolean {
+  const mql = getMediaQuery()
+  return hasTouchScreen() && !!mql && mql.matches
+}
+
+function getServerSnapshot(): boolean {
+  return false
+}
+
+/**
+ * useIsMobile — `true` su dispositivi touch con viewport ≤ 767px.
+ *
+ * Hook condiviso: tutti i consumer leggono lo stesso store con una **sola**
+ * sottoscrizione `matchMedia` (via `useSyncExternalStore` + singleton),
+ * così una lista di N card non monta N listener duplicati.
+ */
+export function useIsMobile(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/src/lib/__tests__/a11y.test.ts
+++ b/src/lib/__tests__/a11y.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { inlineErrorAttrs } from '../a11y'
+
+describe('inlineErrorAttrs', () => {
+  it('in errore: aria-invalid true e describedby = id messaggio', () => {
+    expect(inlineErrorAttrs(true, 'pwd-error')).toEqual({
+      'aria-invalid': true,
+      'aria-describedby': 'pwd-error',
+    })
+  })
+
+  it('senza errore e senza hint: entrambi omessi (undefined)', () => {
+    expect(inlineErrorAttrs(false, 'pwd-error')).toEqual({
+      'aria-invalid': undefined,
+      'aria-describedby': undefined,
+    })
+  })
+
+  it('senza errore ma con hint: describedby = id hint, aria-invalid omesso', () => {
+    expect(inlineErrorAttrs(false, 'code-error', 'code-hint')).toEqual({
+      'aria-invalid': undefined,
+      'aria-describedby': 'code-hint',
+    })
+  })
+})

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -1,0 +1,20 @@
+/**
+ * Attributi ARIA per un input con errore inline gestito a mano (stato locale,
+ * fuori da react-hook-form). Uniforma il pattern altrimenti duplicato nei
+ * dialog con validazione manuale (es. DeleteAccountDialog, AcceptInviteFlowDialog):
+ * `aria-invalid` presente solo in errore e `aria-describedby` che punta al
+ * messaggio d'errore o, in sua assenza, a un eventuale testo di aiuto.
+ *
+ * I form basati su react-hook-form usano invece `FormControl` (in `ui/form.tsx`),
+ * che deriva `aria-invalid` dallo stato del campo: non passare da qui.
+ */
+export function inlineErrorAttrs(
+  hasError: boolean,
+  errorId: string,
+  describedByWhenValid?: string
+): { 'aria-invalid': true | undefined; 'aria-describedby': string | undefined } {
+  return {
+    'aria-invalid': hasError ? true : undefined,
+    'aria-describedby': hasError ? errorId : describedByWhenValid,
+  }
+}


### PR DESCRIPTION
## Sommario

Fase B della **coda Impeccable** (#34): affronta i **6 item residui** rinviati/pre-esistenti dopo le unità #15–#23. Scope concordato = **tutti e 6**. Non chiude #34 (resta aperta per le note di governance: chiusura epic #13, `TestConnection`).

## Item

| # | Tipo | File | Modifica |
|---|------|------|----------|
| 1 | Perf (era #15) | `hooks/useIsMobile.ts` (nuovo), `SwipeableCard.tsx` | Hook condiviso `useSyncExternalStore` + singleton `matchMedia` → **una sola** sottoscrizione per N card (prima: un `resize` listener per-card). Degrada a non-mobile dove `matchMedia` manca (jsdom/SSR). |
| 4 | Micro-UI (era #16 P3) | `FoodForm.tsx` | Header accordion **chiuso**: `bg-primary/10` (verde) → `bg-muted/50` (neutro). Bottone barcode lasciato `bg-primary/10` (CTA deliberata). |
| 5 | Consistency (era #20) | `lib/a11y.ts` (nuovo), `DeleteAccountDialog.tsx`, `AcceptInviteFlowDialog.tsx` | Helper `inlineErrorAttrs()` uniforma il pattern manuale `aria-invalid`/`aria-describedby`. **`FormControl` (RHF) non toccato** — cambiarlo impatterebbe ogni form (fuori scope, già flaggato in #20). |
| 6 | Logic (era #21) | `DeleteAccountDialog.tsx` | Guard refetch `!foodCount` → `foodCount === null`: con 0 alimenti reali non rifà la query a ogni apertura. |
| 7 | Tech-debt React 19 | `ui/{dialog,alert-dialog,dropdown-menu,form,label}.tsx` | Sweep `React.ElementRef` → `React.ComponentRef` (0 occorrenze residue). |
| 3 | A11y/visual (era #20) | — | **Chiuso come non-issue (artefatto headless)**, nessuna modifica. `--ring` è verde (hue 142) in entrambi i temi, nessuna regola `outline`/ambra punta a `DialogContent`, che riceve solo focus **programmatico** (Radix `tabindex=-1`) → niente `:focus-visible` nei browser reali. Tap-test su device reale = dominio utente. |

## Verifiche
- `tsc -b` → ✅ · `npm run build` (vite + SW PWA) → ✅
- `npm test` → ✅ **128/128** (+10: useIsMobile 6, a11y 3, DeleteAccountDialog 1)
- `npm run detect:design` sui file modificati → **0 findings**
- code-simplifier (Agent) → nessuna semplificazione (codice già pulito); segnalati pre-esistenti fuori scope (`cardRef` inutilizzata e doppia transizione transform in SwipeableCard, assenza di `SwipeableCard.test`)

> Screenshot live non allegati: 5/6 item sono non-visivi (perf/a11y/tech-debt); l'unico visivo (item 4) è uno swap di token coperto dai test `FoodForm`.

Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)