### PR TITLE
feat: animazioni accessibili e feedback aptico onesto su iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Fixed
+- **Feedback aptico onesto su iOS**: WebKit non espone la Vibration API e il workaround `<input switch>` non vibra su trigger programmatico, quindi su iPhone/Safari (anche come PWA installata) il feedback aptico non può funzionare. L'impostazione "Feedback aptico" ora compare solo dove il browser supporta davvero la vibrazione (Android) e non viene più mostrata su iOS, dove prometteva qualcosa che non poteva mantenere.
+- **Movimento ridotto rispettato ovunque**: la preferenza di sistema "riduci movimento" (`prefers-reduced-motion`) è ora onorata globalmente per tutte le animazioni (spinner, swipe, transizioni, toast); la dimostrazione automatica dello swipe non parte più con il movimento ridotto.
+
+### Changed
+- Le sezioni del modulo "aggiungi/modifica alimento" (accordion) ora si aprono e si chiudono con una transizione fluida invece di comparire e sparire di scatto.
+
 ## [1.7.3] - 2026-06-11
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Il progetto copre l'intero ciclo di vita di un'applicazione web: dal design del 
 - **Supporto offline completo** — Cache persistente in IndexedDB, CRUD offline con coda mutazioni e sync automatica al ritorno della connessione
 - **Push notifications** — Avvisi giornalieri per alimenti in scadenza, personalizzabili per anticipo, ore silenziose e limite giornaliero
 - **Vista calendario** — Agenda verticale dei prossimi 7 giorni: l'intera settimana a colpo d'occhio, ogni giorno con conteggio e urgenza delle scadenze
-- **Swipe gestures** — Swipe destro per modificare, sinistro per eliminare (mobile), con feedback aptico
-- **Feedback aptico** — Vibrazione tattile su swipe, creazione, modifica ed eliminazione alimenti (iOS Safari 17.4+ e Android)
+- **Swipe gestures** — Swipe destro per modificare, sinistro per eliminare (mobile)
+- **Feedback aptico** — Vibrazione tattile su swipe, creazione, modifica ed eliminazione alimenti (su Android e browser che espongono la Vibration API; non disponibile su iOS/Safari)
 - **Dark mode** — Light, dark e automatico (segue il sistema)
 - **PWA installabile** — Installabile da browser su iOS e Android con esperienza offline nativa
 - **GDPR compliant** — Export dati personali (Art. 20), cancellazione account (Art. 17), Privacy Policy e T&C integrati

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -107,7 +107,7 @@ Se hai dimenticato la password, puoi reimpostarla facilmente:
 
 **Su Mobile:**
 - Fai uno **swipe verso destra** sulla card dell'alimento
-- Sentirai una vibrazione quando raggiungi la soglia di azione
+- Dove supportato (Android) sentirai una vibrazione quando raggiungi la soglia di azione
 
 ### Eliminare un Alimento
 
@@ -119,7 +119,7 @@ Se hai dimenticato la password, puoi reimpostarla facilmente:
 - Fai uno **swipe verso sinistra** sulla card dell'alimento
 - Conferma l'eliminazione
 
-> **Feedback aptico**: su dispositivi supportati (iOS 17.4+, Android) riceverai una vibrazione tattile durante lo swipe e alla conferma delle azioni. Puoi disattivarlo da **Impostazioni > Feedback Aptico**.
+> **Feedback aptico**: su Android (dove il browser espone la vibrazione) riceverai una vibrazione tattile durante lo swipe e alla conferma delle azioni. Su iPhone/Safari il web non supporta questa funzione. Puoi disattivarlo da **Impostazioni > Feedback Aptico**.
 
 ### Capire i Colori
 
@@ -315,7 +315,7 @@ Le notifiche vengono inviate ogni giorno alle **10:00 (ora italiana)**. Ricevera
 
 ## Feedback Aptico
 
-Su dispositivi supportati (iOS 17.4+ e Android), Entro fornisce vibrazione tattile durante le interazioni principali:
+Su dispositivi il cui browser espone la Vibration API (Android), Entro fornisce vibrazione tattile durante le interazioni principali. Su iPhone/Safari il web non espone questa API, quindi il feedback aptico non è disponibile:
 
 - **Swipe**: vibrazione leggera quando raggiungi la soglia di azione, più intensa alla conferma
 - **Creazione/modifica alimento**: vibrazione di successo
@@ -326,7 +326,7 @@ Su dispositivi supportati (iOS 17.4+ e Android), Entro fornisce vibrazione tatti
 1. Vai in **Impostazioni**
 2. Nella sezione **Feedback Aptico**, premi **"Attiva"** o **"Disattiva"**
 
-> **Nota**: questa opzione appare solo su dispositivi che supportano il feedback aptico. Su desktop non è disponibile.
+> **Nota**: questa opzione appare solo su dispositivi che supportano il feedback aptico. Su desktop e su iPhone non è disponibile.
 
 ---
 

--- a/src/components/auth/AuthLoadingScreen.tsx
+++ b/src/components/auth/AuthLoadingScreen.tsx
@@ -6,7 +6,7 @@ export function AuthLoadingScreen() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="text-center" role="status">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
+        <div className="h-8 w-8 animate-spin motion-reduce:animate-none rounded-full border-4 border-primary border-t-transparent mx-auto" />
         <p className="mt-4 text-sm text-muted-foreground">Caricamento...</p>
       </div>
     </div>

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -14,7 +14,7 @@ export function ProtectedRoute() {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center" role="status">
-          <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
+          <div className="h-12 w-12 animate-spin motion-reduce:animate-none rounded-full border-4 border-primary border-t-transparent mx-auto" />
           <p className="mt-4 text-sm text-muted-foreground">Caricamento...</p>
         </div>
       </div>

--- a/src/components/barcode/BarcodeScanner.tsx
+++ b/src/components/barcode/BarcodeScanner.tsx
@@ -138,7 +138,7 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
             {state === 'idle' && (
               <div className="absolute inset-0 flex items-center justify-center" role="status" aria-live="polite">
                 <div className="flex flex-col items-center gap-3 text-white">
-                  <Loader2 className="h-8 w-8 animate-spin" aria-hidden="true" />
+                  <Loader2 className="h-8 w-8 animate-spin motion-reduce:animate-none" aria-hidden="true" />
                   <p className="text-sm">Inizializzazione fotocamera...</p>
                 </div>
               </div>
@@ -148,7 +148,7 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
             {isProcessing && (
               <div className="absolute inset-0 bg-black/60 rounded-lg flex items-center justify-center" role="status" aria-live="polite">
                 <div className="bg-background p-4 rounded-lg flex flex-col items-center gap-2">
-                  <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden="true" />
+                  <Loader2 className="h-6 w-6 animate-spin motion-reduce:animate-none text-primary" aria-hidden="true" />
                   <p className="text-sm font-medium">Elaborazione...</p>
                 </div>
               </div>
@@ -184,7 +184,7 @@ export function BarcodeScanner({ open, onOpenChange, onScanSuccess }: BarcodeSca
                 Posiziona il codice a barre all'interno del riquadro
               </p>
               <div className="flex items-center justify-center gap-2">
-                <div className="h-2 w-2 rounded-full bg-primary animate-pulse" aria-hidden="true" />
+                <div className="h-2 w-2 rounded-full bg-primary animate-pulse motion-reduce:animate-none" aria-hidden="true" />
                 <p className="text-xs text-muted-foreground">Scanner attivo</p>
               </div>
             </div>

--- a/src/components/foods/FoodCard.tsx
+++ b/src/components/foods/FoodCard.tsx
@@ -100,7 +100,7 @@ export function FoodCard({ food, category, onEdit, onDelete, showHintAnimation =
           'hover:shadow-md transition-shadow',
           (status === 'expired' || status === 'expires_today') && 'border-destructive/40',
           (status === 'expires_soon' || status === 'expires_this_week') && daysUntilExpiry <= 3 && 'border-warning/50',
-          isRemoteUpdate && 'ring-2 ring-primary animate-pulse'
+          isRemoteUpdate && 'ring-2 ring-primary animate-pulse motion-reduce:animate-none'
         )}
       >
         <CardHeader className="pb-3">
@@ -135,7 +135,7 @@ export function FoodCard({ food, category, onEdit, onDelete, showHintAnimation =
               return (
                 <div className="w-full h-40 rounded-lg overflow-hidden bg-muted/20 mb-3 relative">
                   <div className="w-full h-full flex items-center justify-center">
-                    <Loader2 className="w-8 h-8 text-muted-foreground/70 animate-spin" />
+                    <Loader2 className="w-8 h-8 text-muted-foreground/70 animate-spin motion-reduce:animate-none" />
                   </div>
                 </div>
               )

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, lazy, Suspense } from 'react'
+import { useEffect, useState, useRef, lazy, Suspense, type ReactNode } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { format } from 'date-fns'
@@ -31,6 +31,45 @@ function getSubmitButtonText(mode: 'create' | 'edit', isSubmitting: boolean): st
     return mode === 'create' ? 'Creazione in corso...' : 'Salvataggio in corso...'
   }
   return mode === 'create' ? 'Aggiungi alimento' : 'Salva modifiche'
+}
+
+/**
+ * CollapsibleSection — accordion panel that animates open/closed via
+ * `grid-template-rows: 0fr → 1fr` (layout-safe: no animating of `height`).
+ *
+ * `hidden` (display:none) is applied only once the collapse transition ends, so
+ * the panel animates out before it leaves the layout (dropping the form's
+ * `space-y` gap) and the tab order / a11y tree. `inert` covers the brief window
+ * while it is collapsing-but-still-visible. The `hidden` flag starts matching
+ * `open`, so the first render is correct without a transition (jsdom, the test
+ * environment, never fires `transitionend`).
+ */
+function CollapsibleSection({ id, open, children }: { id: string; open: boolean; children: ReactNode }) {
+  const [hidden, setHidden] = useState(!open)
+
+  useEffect(() => {
+    if (open) setHidden(false) // reveal an opening section immediately
+  }, [open])
+
+  return (
+    <div
+      id={id}
+      data-testid={id}
+      inert={!open || undefined}
+      onTransitionEnd={(e) => {
+        if (e.propertyName === 'grid-template-rows' && !open) setHidden(true)
+      }}
+      className={cn(
+        'grid transition-[grid-template-rows] duration-200 ease-[var(--ease-out-quart)] motion-reduce:transition-none',
+        open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+        hidden && 'hidden'
+      )}
+    >
+      <div className="overflow-hidden">
+        <div className="space-y-4">{children}</div>
+      </div>
+    </div>
+  )
 }
 
 interface FoodFormProps {
@@ -267,7 +306,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
               role="status"
               aria-live="polite"
             >
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
               Caricamento scanner...
             </div>
           }
@@ -323,7 +362,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
             )}
           </button>
 
-          <div id="section-main" data-testid="section-main" className={openSection !== 'main' ? 'hidden' : 'space-y-4'}>
+          <CollapsibleSection id="section-main" open={openSection === 'main'}>
             {/* Barcode Scanner Button - Only in create mode */}
             {mode === 'create' && (
               <div className="pb-2">
@@ -336,7 +375,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                 >
                   {isLoadingProduct ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
                       Caricamento dati prodotto...
                     </>
                   ) : (
@@ -520,7 +559,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                 )}
               />
             </div>
-          </div>
+          </CollapsibleSection>
 
           {/* === ACCORDION SECTION: Dettagli aggiuntivi === */}
           <button
@@ -543,7 +582,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
             )}
           </button>
 
-          <div id="section-details" data-testid="section-details" className={openSection !== 'details' ? 'hidden' : 'space-y-4'}>
+          <CollapsibleSection id="section-details" open={openSection === 'details'}>
             {/* Image Upload Field */}
             <FormField
               control={form.control}
@@ -583,7 +622,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
                 </FormItem>
               )}
             />
-          </div>
+          </CollapsibleSection>
 
           {/* Form Actions - Always visible outside accordion sections */}
           <div className="flex gap-3 pt-4 border-t">

--- a/src/components/foods/FoodModals.tsx
+++ b/src/components/foods/FoodModals.tsx
@@ -22,7 +22,7 @@ const FoodForm = lazy(() => import('./FoodForm').then(m => ({ default: m.FoodFor
 
 const FormSpinner = () => (
   <div className="flex justify-center py-8" role="status" aria-live="polite">
-    <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" aria-hidden="true" />
+    <div className="h-8 w-8 animate-spin motion-reduce:animate-none rounded-full border-4 border-border border-t-primary" aria-hidden="true" />
     <span className="sr-only">Caricamento modulo...</span>
   </div>
 )

--- a/src/components/foods/ImageUpload.tsx
+++ b/src/components/foods/ImageUpload.tsx
@@ -141,14 +141,14 @@ export function ImageUpload({ value, onChange, disabled = false }: ImageUploadPr
             {isLoadingPreview ? (
               <div className="absolute inset-0 bg-black/50 flex items-center justify-center" role="status" aria-live="polite">
                 <div className="text-white text-center">
-                  <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" aria-hidden="true" />
+                  <Loader2 className="w-8 h-8 animate-spin motion-reduce:animate-none mx-auto mb-2" aria-hidden="true" />
                   <p className="text-sm">Caricamento immagine...</p>
                 </div>
               </div>
             ) : isConverting ? (
               <div className="absolute inset-0 bg-black/50 flex items-center justify-center" role="status" aria-live="polite">
                 <div className="text-white text-center">
-                  <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" aria-hidden="true" />
+                  <Loader2 className="w-8 h-8 animate-spin motion-reduce:animate-none mx-auto mb-2" aria-hidden="true" />
                   <p className="text-sm">Conversione immagine HEIC...</p>
                 </div>
               </div>

--- a/src/components/foods/SwipeableCard.tsx
+++ b/src/components/foods/SwipeableCard.tsx
@@ -35,6 +35,9 @@ export function SwipeableCard({ children, onEdit, onDelete, className, showHintA
   // Animated hint: mini-swipe demonstration on first card (first time only)
   useEffect(() => {
     if (!showHintAnimation || !isMobile) return
+    // Respect reduced motion: skip the auto-playing swipe demo entirely. We don't
+    // mark it as "seen" so it can still play if the user later allows motion.
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
 
     const hasSeenAnimation = localStorage.getItem(HINT_ANIMATION_KEY) === 'true'
     if (hasSeenAnimation) return
@@ -168,14 +171,12 @@ export function SwipeableCard({ children, onEdit, onDelete, className, showHintA
       {/* Card content with swipe transform */}
       <div
         {...handlers}
-        className={cn(
-          'relative bg-card',
-          isAnimating ? 'transition-transform duration-200 ease-out' : '',
-          className
-        )}
+        className={cn('relative bg-card', className)}
         style={{
           transform: `translateX(${swipeOffset}px)`,
-          transition: isAnimating ? 'transform 0.2s ease-out' : 'none',
+          // The inline transition governs the swipe animation (it always wins over
+          // a Tailwind class); `none` while idle so dragging tracks the finger 1:1.
+          transition: isAnimating ? 'transform 0.2s var(--ease-out-quart)' : 'none',
         }}
       >
         {children}

--- a/src/components/foods/__tests__/FoodForm.test.tsx
+++ b/src/components/foods/__tests__/FoodForm.test.tsx
@@ -172,4 +172,33 @@ describe('FoodForm accordion sections', () => {
       expect(detailsSection).toHaveClass('hidden')
     })
   })
+
+  it('keeps the collapsed section out of the tab order and a11y tree (inert + hidden)', () => {
+    render(<FoodForm mode="create" onSubmit={mockOnSubmit} />)
+
+    const mainSection = document.getElementById('section-main')!
+    const detailsSection = document.getElementById('section-details')!
+
+    // Open section: reachable, announced.
+    expect(mainSection).not.toHaveAttribute('inert')
+    expect(mainSection).not.toHaveClass('hidden')
+    // Collapsed section: inert (no focus) + hidden (no layout / not announced).
+    expect(detailsSection).toHaveAttribute('inert')
+    expect(detailsSection).toHaveClass('hidden')
+  })
+
+  it('reveals a section when opened: drops inert/hidden and flips aria-expanded', async () => {
+    const user = userEvent.setup()
+    render(<FoodForm mode="create" onSubmit={mockOnSubmit} />)
+
+    const detailsButton = document.querySelector('button[aria-controls="section-details"]')!
+    expect(detailsButton).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(detailsButton)
+
+    const detailsSection = document.getElementById('section-details')!
+    expect(detailsButton).toHaveAttribute('aria-expanded', 'true')
+    expect(detailsSection).not.toHaveAttribute('inert')
+    expect(detailsSection).not.toHaveClass('hidden')
+  })
 })

--- a/src/components/guide/QuickGuideDialog.tsx
+++ b/src/components/guide/QuickGuideDialog.tsx
@@ -31,7 +31,7 @@ const guideItems = [
   {
     icon: ArrowLeftRight,
     title: 'Modifica ed elimina',
-    description: 'Swipe dx per modificare, sx per eliminare con vibrazione tattile (su desktop usa i pulsanti)',
+    description: 'Swipe dx per modificare, sx per eliminare (su desktop usa i pulsanti)',
   },
   {
     icon: Palette,

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,9 @@
     --input: 0 0% 89.8%;
     --ring: 142.1 76.2% 36.3%;
     --radius: 0.5rem;
+    /* Motion: shared deceleration curve (calm, decisive) for swipe, accordion
+       and press feedback. */
+    --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -87,6 +90,23 @@
   .dark input[type="date"]::-webkit-calendar-picker-indicator {
     filter: invert(1);
     cursor: pointer;
+  }
+}
+
+/* Accessibility: honour the OS "reduce motion" setting globally. Safety net so
+   any animation added without an explicit `motion-reduce:*` utility (swipe
+   transform, FAB press, the remote-update pulse, Sonner toasts) still calms
+   down. Per-element `motion-reduce:*` utilities are kept for intent + tests.
+   Durations are near-zero rather than 0s so `transitionend`/`animationend`
+   still fire — the food-form accordion relies on `onTransitionEnd`. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 

--- a/src/lib/__tests__/haptics.test.ts
+++ b/src/lib/__tests__/haptics.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+// Mock web-haptics so constructing an instance has no DOM/audio side effects;
+// the spy lets us assert the preset is forwarded when (and only when) it should.
+const { triggerSpy } = vi.hoisted(() => ({ triggerSpy: vi.fn() }))
+vi.mock('web-haptics', () => ({
+  WebHaptics: class {
+    trigger = triggerSpy
+  },
+}))
+
+const IPHONE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36'
+
+// Minimal in-memory localStorage so the module's preference lookup works while
+// `navigator` is stubbed (the stub detaches jsdom's own storage binding).
+function makeLocalStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size
+    },
+  } as Storage
+}
+
+// Reload the module with a fresh navigator + storage so the module-level
+// support/enabled caches start clean for each case.
+async function loadHaptics(nav: Partial<Navigator>) {
+  vi.resetModules()
+  vi.stubGlobal('navigator', nav)
+  vi.stubGlobal('localStorage', makeLocalStorage())
+  return import('../haptics')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('rilevamento supporto haptic', () => {
+  it('è supportato quando navigator.vibrate è una funzione (Android)', async () => {
+    const h = await loadHaptics({ vibrate: vi.fn(), userAgent: ANDROID_UA } as Partial<Navigator>)
+    expect(h.isHapticsSupported()).toBe(true)
+  })
+
+  it('NON è supportato su iPhone (WebKit non espone la Vibration API)', async () => {
+    const h = await loadHaptics({ userAgent: IPHONE_UA } as Partial<Navigator>)
+    expect(h.isHapticsSupported()).toBe(false)
+  })
+
+  it('NON è supportato su desktop senza Vibration API', async () => {
+    const h = await loadHaptics({ userAgent: 'Mozilla/5.0 (Macintosh)' } as Partial<Navigator>)
+    expect(h.isHapticsSupported()).toBe(false)
+  })
+})
+
+describe('preferenza haptic', () => {
+  it('è abilitato di default quando non c\'è una preferenza salvata', async () => {
+    const h = await loadHaptics({ vibrate: vi.fn() } as Partial<Navigator>)
+    expect(h.isHapticsEnabled()).toBe(true)
+  })
+
+  it('è false dove non supportato, a prescindere dalla preferenza', async () => {
+    const h = await loadHaptics({ userAgent: IPHONE_UA } as Partial<Navigator>)
+    expect(h.isHapticsEnabled()).toBe(false)
+  })
+})
+
+describe('triggerHaptic', () => {
+  it('è un no-op dove non supportato (es. iPhone)', async () => {
+    const h = await loadHaptics({ userAgent: IPHONE_UA } as Partial<Navigator>)
+    h.triggerHaptic('success')
+    expect(triggerSpy).not.toHaveBeenCalled()
+  })
+
+  it('inoltra il preset alla libreria quando supportato e abilitato', async () => {
+    const h = await loadHaptics({ vibrate: vi.fn() } as Partial<Navigator>)
+    h.triggerHaptic('nudge')
+    expect(triggerSpy).toHaveBeenCalledWith('nudge')
+  })
+})

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -8,21 +8,19 @@ let instance: WebHaptics | null = null
 let enabledCache: boolean | null = null
 
 /**
- * Check if haptic feedback can work on this device.
- * - Android/desktop: navigator.vibrate exists
- * - iOS Safari 17.4+: no vibrate API, but web-haptics uses a hidden
- *   <input type="checkbox" switch> workaround for native haptic feedback
+ * Check if haptic feedback can actually fire on this device.
+ *
+ * Only the standard Vibration API (`navigator.vibrate`) delivers reliable,
+ * programmatic haptics — that means Android (Chrome/Firefox/Edge). iOS/WebKit
+ * does NOT implement `navigator.vibrate`, and the `<input type="checkbox" switch>`
+ * trick only vibrates on a real user toggle of the control, never on a
+ * programmatic `trigger()`. So we report support strictly where the Vibration
+ * API exists; everywhere else (e.g. iPhone, Safari) the "Feedback aptico"
+ * setting stays hidden instead of promising feedback we can't deliver.
  */
 function canHaptics(): boolean {
   if (typeof navigator === 'undefined') return false
-  // Android / standard Vibration API
-  if (typeof navigator.vibrate === 'function') return true
-  // iOS Safari: no vibrate, but the checkbox switch workaround works
-  const ua = navigator.userAgent
-  if (/iPad|iPhone/.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) {
-    return true
-  }
-  return false
+  return typeof navigator.vibrate === 'function'
 }
 
 let supportedCache: boolean | null = null

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -249,7 +249,7 @@ export function DashboardPage() {
       {foodsLoading ? (
         <div className="flex items-center justify-center py-12" role="status" aria-live="polite">
           <div className="flex flex-col items-center gap-3">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" aria-hidden="true"></div>
+            <div className="h-8 w-8 animate-spin motion-reduce:animate-none rounded-full border-4 border-border border-t-primary" aria-hidden="true"></div>
             <div className="text-muted-foreground">Caricamento alimenti...</div>
           </div>
         </div>
@@ -363,7 +363,7 @@ export function DashboardPage() {
           {viewMode === 'calendar' ? (
             <Suspense fallback={
               <div className="flex items-center justify-center py-12" role="status" aria-label="Caricamento calendario">
-                <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" aria-hidden="true"></div>
+                <div className="h-8 w-8 animate-spin motion-reduce:animate-none rounded-full border-4 border-border border-t-primary" aria-hidden="true"></div>
               </div>
             }>
               <WeekView
@@ -410,7 +410,7 @@ export function DashboardPage() {
       {/* Floating Action Button (FAB) - Mobile Only */}
       <button
         onClick={() => setIsAddDialogOpen(true)}
-        className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 active:scale-95 transition-all flex items-center justify-center sm:hidden"
+        className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 active:scale-95 transition-[transform,background-color] duration-150 ease-[var(--ease-out-quart)] flex items-center justify-center sm:hidden"
         aria-label="Aggiungi alimento"
       >
         <Plus className="h-6 w-6" />

--- a/src/pages/GuidaPage.tsx
+++ b/src/pages/GuidaPage.tsx
@@ -83,7 +83,7 @@ export function GuidaPage() {
           <div>
             <h3 className="font-medium mb-2">Modificare</h3>
             <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
-              <li><strong className="text-foreground">Mobile:</strong> swipe verso destra sulla card (vibrazione alla soglia)</li>
+              <li><strong className="text-foreground">Mobile:</strong> swipe verso destra sulla card (con vibrazione dove supportata)</li>
               <li><strong className="text-foreground">Desktop:</strong> clicca il pulsante "Modifica"</li>
             </ul>
           </div>
@@ -93,11 +93,12 @@ export function GuidaPage() {
               Eliminare
             </h3>
             <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
-              <li><strong className="text-foreground">Mobile:</strong> swipe verso sinistra sulla card (vibrazione alla soglia)</li>
+              <li><strong className="text-foreground">Mobile:</strong> swipe verso sinistra sulla card (con vibrazione dove supportata)</li>
               <li><strong className="text-foreground">Desktop:</strong> clicca il pulsante "Elimina"</li>
             </ul>
             <p className="text-xs text-muted-foreground mt-2">
-              Il feedback aptico si può disattivare da Impostazioni &gt; Feedback Aptico.
+              Il feedback aptico è disponibile dove il browser supporta la vibrazione (es. Android)
+              e si può disattivare da Impostazioni &gt; Feedback Aptico.
             </p>
           </div>
           <div>


### PR DESCRIPTION
## Cosa

Due interventi collegati: sessione Impeccable `animate` (register product) + fix di coerenza dell'haptic.

### Feedback aptico onesto su iOS
- `canHaptics()` (`src/lib/haptics.ts`) ora riporta supporto **solo** dove `navigator.vibrate` è una funzione (rimosso il ramo UA iPhone/iPad). iOS/WebKit non espone la Vibration API e il workaround `<input switch>` di `web-haptics` non vibra su trigger programmatico → su iPhone (anche PWA installata) il feedback non parte mai. Effetto: la card "Feedback aptico" (`HapticSettings`) è nascosta su iOS invece di promettere il falso; **Android invariato**.

### Animazioni (registro product: calmo, 150–250ms)
- **`prefers-reduced-motion` completo**: blocco globale in `src/index.css` (durate `0.01ms`, non `0s`, così `transitionend` continua a scattare per l'accordion) + `motion-reduce:animate-none` sugli spinner/pulse scoperti + guard `matchMedia` sulla demo-swipe automatica.
- **Accordion del form alimento fluido**: nuovo componente locale `CollapsibleSection` (`grid-template-rows: 0fr→1fr` + `overflow-hidden`), a11y preservata con `inert` + `hidden` ritardato a `onTransitionEnd` (chiusura animata, apertura istantanea; primo render corretto per jsdom).
- **Token easing `--ease-out-quart`** condiviso da swipe/accordion/FAB; FAB `transition-all` → `transition-[transform,background-color]`.

### Documentazione
- Rimossi i claim falsi "iOS 17.4+" in `README`, `docs/guides/USER_GUIDE.md`, guida in-app (`GuidaPage`/`QuickGuideDialog`); voce `CHANGELOG [Unreleased]`. Doc interni gitignored aggiornati su disco (`CROSS_BROWSER_TESTING`, `IMPECCABLE_REVIEW`, `ACCESSIBILITY_AUDIT`, `FEATURES`).
- Convention cross-prodotto aggiunta in `entro-family` (`conventions/motion-haptics-accessibility.md`).

## Test & verifica
- `tsc -b` ✅ · `npm run build` ✅ · lint **0 errori** (4 warning `react-refresh` pre-esistenti).
- Test del perimetro toccato verdi: nuovo `src/lib/__tests__/haptics.test.ts` (matrice supporto/preferenza/no-op) + 2 test a11y accordion (`inert`/`hidden`, `aria-expanded`); FoodForm 8/8, HapticSettings 3/3, PageLoader.
- `code-simplifier` eseguito: nessuna semplificazione necessaria (solo cleanup di una className `transition` morta in `SwipeableCard`, tracciabile al cambio di easing).

## Note
- ⚠️ Fuori scope: `ThemeProvider.test` / `NotificationPrompt.test` falliscono per `localStorage` undefined in jsdom — **pre-esistente** (verificato su `main` pulito con tutto in stash), tracciato in #40.
- L'haptic resta non realizzabile su iPhone via web; haptic veri = app nativa (`entro-mobile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
