### PR TITLE
test: localStorage funzionante nei test jsdom su Node 25+ (closes #40)

### DIFF
--- a/src/lib/__tests__/haptics.test.ts
+++ b/src/lib/__tests__/haptics.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach, vi } from 'vitest'
+import { makeLocalStorage } from '@/test/localStorage'
 
 // Mock web-haptics so constructing an instance has no DOM/audio side effects;
 // the spy lets us assert the preset is forwarded when (and only when) it should.
@@ -14,22 +15,6 @@ const IPHONE_UA =
   'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
 const ANDROID_UA =
   'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36'
-
-// Minimal in-memory localStorage so the module's preference lookup works while
-// `navigator` is stubbed (the stub detaches jsdom's own storage binding).
-function makeLocalStorage(): Storage {
-  const store = new Map<string, string>()
-  return {
-    getItem: (k) => (store.has(k) ? store.get(k)! : null),
-    setItem: (k, v) => void store.set(k, String(v)),
-    removeItem: (k) => void store.delete(k),
-    clear: () => store.clear(),
-    key: (i) => [...store.keys()][i] ?? null,
-    get length() {
-      return store.size
-    },
-  } as Storage
-}
 
 // Reload the module with a fresh navigator + storage so the module-level
 // support/enabled caches start clean for each case.

--- a/src/test/localStorage.ts
+++ b/src/test/localStorage.ts
@@ -1,0 +1,17 @@
+// Map-backed in-memory Storage used across tests. Node 25+ ships an experimental
+// built-in `localStorage` global that, without `--localstorage-file`, resolves to
+// `undefined` (see vitest#8757 / nodejs#60303); jsdom under an opaque origin doesn't
+// expose one either. This factory gives tests a deterministic, spec-shaped Storage.
+export function makeLocalStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size
+    },
+  } as Storage
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,13 @@
+import { makeLocalStorage } from './localStorage'
+
+// Install a working `localStorage` global for every test file. Node 25+ defines a
+// built-in experimental `localStorage` accessor that returns `undefined` without
+// `--localstorage-file`, and because the global already "exists" the jsdom
+// environment doesn't install a usable one over it (vitest#8757, closed as an
+// upstream Node behaviour). `defineProperty` reliably replaces whatever shape the
+// built-in takes across Node versions; tests that need isolation call `.clear()`.
+Object.defineProperty(globalThis, 'localStorage', {
+  value: makeLocalStorage(),
+  writable: true,
+  configurable: true,
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,11 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    setupFiles: ['./src/test/setup.ts'],
+    // Node 25+ enables experimental Web Storage by default; without a backing file
+    // its built-in `localStorage` resolves to `undefined` and shadows the one tests
+    // expect (vitest#8757). Disabling it lets our setup own the global cleanly and
+    // silences the `--localstorage-file` ExperimentalWarning.
+    execArgv: ['--no-experimental-webstorage'],
   },
 })


### PR DESCRIPTION
## Contesto

Risolve #40. Su `main` pulito, 9 test fallivano (`2 file falliti | 29 passati`) con `TypeError: Cannot read properties of undefined (reading 'clear')` nei `beforeEach` di `ThemeProvider.test.tsx` e `NotificationPrompt.test.tsx` che chiamano `localStorage.clear()`.

## Causa radice (confermata da fonti ufficiali)

- **Node ≥25** (qui v26.3.0) abilita il **Web Storage built-in di default** ([nodejs#57666](https://github.com/nodejs/node/pull/57666)). Senza `--localstorage-file`, `globalThis.localStorage` è un accessor che restituisce `undefined` + `ExperimentalWarning`.
- Poiché il global *esiste già*, l'ambiente jsdom di vitest **non installa** uno `localStorage` funzionante sopra → `localStorage.clear()` esplode.
- Comportamento upstream di Node, **non un bug di vitest**: [vitest#8757](https://github.com/vitest-dev/vitest/issues/8757) è chiusa come non risolvibile lato vitest (4.1.9 non lo corregge). Serve un workaround di config.
- Nota: `environmentOptions.jsdom.url` riguarda un errore *diverso* (opaque origin, [vitest#1605](https://github.com/vitest-dev/vitest/issues/1605)) e **non** risolve questo caso — verificato empiricamente.

## Soluzione

- `src/test/setup.ts` — installa un polyfill `localStorage` Map-backed come global via `Object.defineProperty(globalThis, 'localStorage', { value, writable, configurable })` (robusto a qualsiasi shape del built-in tra versioni di Node).
- `src/test/localStorage.ts` — helper condiviso `makeLocalStorage()`, estratto da `haptics.test.ts` (rimossa la duplicazione, come suggerito nell'issue).
- `vitest.config.ts` — registra `setupFiles` e aggiunge `execArgv: ['--no-experimental-webstorage']` per neutralizzare la causa radice e silenziare il warning fuorviante.

## Verifica

| Controllo | Prima | Dopo |
|---|---|---|
| `npm test` | 2 file / 9 test falliti | **31 file / 156 test passati** |
| `ExperimentalWarning` localStorage | presente | sparito |
| `tsc -b` | — | exit 0 |
| `eslint` (file toccati) | — | exit 0 |

Nessuna logica dei componenti toccata: solo infrastruttura di test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)