### PR TITLE
chore: forza js-yaml ^4.2.0 per chiudere l'alert DoS (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8485,10 +8485,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ws": "^8.20.1",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "esbuild": "^0.28.1",
+    "js-yaml": "^4.2.0",
     "minimatch@3": {
       "brace-expansion": "^1.1.13"
     },


### PR DESCRIPTION
## Contesto
Chiude l'ultimo alert Dependabot aperto: **js-yaml** (moderate, GHSA-h67p-54hq-rp68 — DoS a complessità quadratica nelle merge key con alias ripetuti).

Catena: `eslint@9.39.2 → @eslint/eslintrc@3.3.3 → js-yaml@4.1.1` — transitivo, **dev-only** (non entra nel bundle di produzione).

## Modifica
- `overrides`: aggiunto `"js-yaml": "^4.2.0"` (prima versione patchata). Stesso pattern usato per le altre dipendenze transitive (ws, serialize-javascript, …).

## Verifica
- `npm ls js-yaml` → **4.2.0**
- `npm audit` → **0 vulnerabilità**
- `npm run lint` → exit 0 (eslint usa js-yaml via eslintrc; nessun errore, solo i 4 warning react-refresh pre-esistenti)
- `npm test` → 31 file / 156 test verdi

L'alert Dependabot si chiuderà da solo dopo il merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)