### PR TITLE
fix: i filtri della dashboard funzionano offline (refs #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Fixed
+- I filtri rapidi "In scadenza" e "Scaduti" ora funzionano anche offline e restano sempre coerenti con il conteggio delle card: filtro e ordinamento sono calcolati dai dati già in cache (stessa fonte dei conteggi), invece di una query separata che offline non era disponibile.
+
 ## [1.7.4] - 2026-06-16
 
 ### Fixed

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -152,6 +152,8 @@ Clicca sulle **card statistiche** in alto:
 - **"In scadenza"**: mostra solo quelli che scadono entro 7 giorni
 - **"Scaduti"**: mostra solo quelli già scaduti
 
+> **Nota**: i filtri rapidi funzionano anche offline. Il risultato mostrato è sempre coerente con il numero indicato sulla card, perché entrambi vengono calcolati dagli stessi dati in cache.
+
 ---
 
 ## Vista Calendario

--- a/src/lib/__tests__/foodFilters.test.ts
+++ b/src/lib/__tests__/foodFilters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import type { Food, FilterParams } from '@/lib/foods'
+import type { Food } from '@/lib/foods'
 import { filterFoods, sortFoods, deriveDashboardData } from '@/lib/foodFilters'
 
 const NOW = new Date('2026-06-16T12:00:00')
@@ -7,14 +7,12 @@ const NOW = new Date('2026-06-16T12:00:00')
 function makeFood(over: Partial<Food> & { name: string; expiry_date: string }): Food {
   return {
     id: over.name,
-    name: over.name,
-    expiry_date: over.expiry_date,
-    category_id: over.category_id ?? null,
-    storage_location: over.storage_location ?? 'fridge',
+    category_id: 'c0',
+    storage_location: 'fridge',
     quantity: null, quantity_unit: null, notes: null, image_url: null,
     barcode: null, status: 'active', consumed_at: null, deleted_at: null,
     user_id: 'u', list_id: null,
-    created_at: over.created_at ?? '2026-06-01T00:00:00Z',
+    created_at: '2026-06-01T00:00:00Z',
     updated_at: '2026-06-01T00:00:00Z',
     ...over,
   } as Food
@@ -76,7 +74,7 @@ describe('filterFoods - categoria / posizione / ricerca', () => {
 describe('sortFoods', () => {
   const items: Food[] = [
     makeFood({ name: 'Banana', expiry_date: '2026-06-20', category_id: 'b', created_at: '2026-06-03T00:00:00Z' }),
-    makeFood({ name: 'ananas', expiry_date: '2026-06-10', category_id: null, created_at: '2026-06-01T00:00:00Z' }),
+    makeFood({ name: 'ananas', expiry_date: '2026-06-10', category_id: 'c', created_at: '2026-06-01T00:00:00Z' }),
     makeFood({ name: 'Cocco', expiry_date: '2026-06-15', category_id: 'a', created_at: '2026-06-02T00:00:00Z' }),
   ]
   it('expiry_date asc (default)', () => {
@@ -91,8 +89,8 @@ describe('sortFoods', () => {
   it('created_at desc', () => {
     expect(sortFoods(items, 'created_at', 'desc').map(f => f.created_at)).toEqual(['2026-06-03T00:00:00Z', '2026-06-02T00:00:00Z', '2026-06-01T00:00:00Z'])
   })
-  it('category_id: i null finiscono in fondo', () => {
-    expect(sortFoods(items, 'category_id', 'asc').map(f => f.category_id)).toEqual(['a', 'b', null])
+  it('category_id asc', () => {
+    expect(sortFoods(items, 'category_id', 'asc').map(f => f.category_id)).toEqual(['a', 'b', 'c'])
   })
   it('non muta l\'array di input', () => {
     const copy = [...items]

--- a/src/lib/__tests__/foodFilters.test.ts
+++ b/src/lib/__tests__/foodFilters.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { Food, FilterParams } from '@/lib/foods'
-import { filterFoods } from '@/lib/foodFilters'
+import { filterFoods, sortFoods } from '@/lib/foodFilters'
 
 const NOW = new Date('2026-06-16T12:00:00')
 
@@ -70,5 +70,33 @@ describe('filterFoods - categoria / posizione / ricerca', () => {
   it('combina filtri: categoria + stato', () => {
     const names = filterFoods(foods, { status: 'expiring_soon', category_id: 'c1' }, NOW).map(f => f.name).sort()
     expect(names).toEqual(['Latte', 'Yogurt'])
+  })
+})
+
+describe('sortFoods', () => {
+  const items: Food[] = [
+    makeFood({ name: 'Banana', expiry_date: '2026-06-20', category_id: 'b', created_at: '2026-06-03T00:00:00Z' }),
+    makeFood({ name: 'ananas', expiry_date: '2026-06-10', category_id: null, created_at: '2026-06-01T00:00:00Z' }),
+    makeFood({ name: 'Cocco', expiry_date: '2026-06-15', category_id: 'a', created_at: '2026-06-02T00:00:00Z' }),
+  ]
+  it('expiry_date asc (default)', () => {
+    expect(sortFoods(items, 'expiry_date', 'asc').map(f => f.expiry_date)).toEqual(['2026-06-10', '2026-06-15', '2026-06-20'])
+  })
+  it('expiry_date desc', () => {
+    expect(sortFoods(items, 'expiry_date', 'desc').map(f => f.expiry_date)).toEqual(['2026-06-20', '2026-06-15', '2026-06-10'])
+  })
+  it('name asc case-insensitive', () => {
+    expect(sortFoods(items, 'name', 'asc').map(f => f.name)).toEqual(['ananas', 'Banana', 'Cocco'])
+  })
+  it('created_at desc', () => {
+    expect(sortFoods(items, 'created_at', 'desc').map(f => f.created_at)).toEqual(['2026-06-03T00:00:00Z', '2026-06-02T00:00:00Z', '2026-06-01T00:00:00Z'])
+  })
+  it('category_id: i null finiscono in fondo', () => {
+    expect(sortFoods(items, 'category_id', 'asc').map(f => f.category_id)).toEqual(['a', 'b', null])
+  })
+  it('non muta l\'array di input', () => {
+    const copy = [...items]
+    sortFoods(items, 'name', 'asc')
+    expect(items).toEqual(copy)
   })
 })

--- a/src/lib/__tests__/foodFilters.test.ts
+++ b/src/lib/__tests__/foodFilters.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { Food, FilterParams } from '@/lib/foods'
-import { filterFoods, sortFoods } from '@/lib/foodFilters'
+import { filterFoods, sortFoods, deriveDashboardData } from '@/lib/foodFilters'
 
 const NOW = new Date('2026-06-16T12:00:00')
 
@@ -98,5 +98,22 @@ describe('sortFoods', () => {
     const copy = [...items]
     sortFoods(items, 'name', 'asc')
     expect(items).toEqual(copy)
+  })
+})
+
+describe('deriveDashboardData', () => {
+  it('stats riflettono i filtri non-stato; lista applica anche lo stato', () => {
+    const { foods: list, stats } = deriveDashboardData(foods, { status: 'expiring_soon', sortBy: 'expiry_date', sortOrder: 'asc' }, NOW)
+    expect(stats.total).toBe(5)
+    expect(stats.expiringSoon).toBe(3)
+    expect(stats.expired).toBe(1)
+    expect(list.map(f => f.name)).toEqual(['Latte', 'Yogurt', 'Pane'])
+    expect(list.length).toBe(stats.expiringSoon)
+  })
+  it('i conteggi rispettano un filtro categoria attivo', () => {
+    const { stats } = deriveDashboardData(foods, { status: 'all', category_id: 'c1' }, NOW)
+    expect(stats.total).toBe(3)
+    expect(stats.expiringSoon).toBe(2)
+    expect(stats.expired).toBe(1)
   })
 })

--- a/src/lib/__tests__/foodFilters.test.ts
+++ b/src/lib/__tests__/foodFilters.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import type { Food, FilterParams } from '@/lib/foods'
+import { filterFoods } from '@/lib/foodFilters'
+
+const NOW = new Date('2026-06-16T12:00:00')
+
+function makeFood(over: Partial<Food> & { name: string; expiry_date: string }): Food {
+  return {
+    id: over.name,
+    name: over.name,
+    expiry_date: over.expiry_date,
+    category_id: over.category_id ?? null,
+    storage_location: over.storage_location ?? 'fridge',
+    quantity: null, quantity_unit: null, notes: null, image_url: null,
+    barcode: null, status: 'active', consumed_at: null, deleted_at: null,
+    user_id: 'u', list_id: null,
+    created_at: over.created_at ?? '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...over,
+  } as Food
+}
+
+const dExpired = '2026-06-15'
+const dToday = '2026-06-16'
+const dSoon = '2026-06-18'
+const dWeek = '2026-06-23'
+const dFresh = '2026-06-24'
+
+const foods: Food[] = [
+  makeFood({ name: 'Latte', expiry_date: dToday, category_id: 'c1', storage_location: 'fridge' }),
+  makeFood({ name: 'Yogurt', expiry_date: dSoon, category_id: 'c1', storage_location: 'fridge' }),
+  makeFood({ name: 'Pane', expiry_date: dWeek, category_id: 'c2', storage_location: 'pantry' }),
+  makeFood({ name: 'Tonno', expiry_date: dFresh, category_id: 'c2', storage_location: 'pantry' }),
+  makeFood({ name: 'Ricotta', expiry_date: dExpired, category_id: 'c1', storage_location: 'fridge' }),
+]
+
+describe('filterFoods - stato (business rule + confini)', () => {
+  it('all → tutti', () => {
+    expect(filterFoods(foods, { status: 'all' }, NOW)).toHaveLength(5)
+  })
+  it('expiring_soon → oggi/soon/this_week (0..7 giorni)', () => {
+    const names = filterFoods(foods, { status: 'expiring_soon' }, NOW).map(f => f.name).sort()
+    expect(names).toEqual(['Latte', 'Pane', 'Yogurt'])
+  })
+  it('expired → solo passato', () => {
+    expect(filterFoods(foods, { status: 'expired' }, NOW).map(f => f.name)).toEqual(['Ricotta'])
+  })
+  it('active → tutto tranne lo scaduto', () => {
+    const names = filterFoods(foods, { status: 'active' }, NOW).map(f => f.name).sort()
+    expect(names).toEqual(['Latte', 'Pane', 'Tonno', 'Yogurt'])
+  })
+  it('confine: +8 giorni è fresh, non expiring_soon', () => {
+    expect(filterFoods([makeFood({ name: 'X', expiry_date: dFresh })], { status: 'expiring_soon' }, NOW)).toHaveLength(0)
+  })
+})
+
+describe('filterFoods - categoria / posizione / ricerca', () => {
+  it('category_id match esatto', () => {
+    expect(filterFoods(foods, { status: 'all', category_id: 'c2' }, NOW).map(f => f.name).sort()).toEqual(['Pane', 'Tonno'])
+  })
+  it('storage_location match esatto', () => {
+    expect(filterFoods(foods, { status: 'all', storage_location: 'pantry' }, NOW).map(f => f.name).sort()).toEqual(['Pane', 'Tonno'])
+  })
+  it('search substring case-insensitive con trim', () => {
+    expect(filterFoods(foods, { status: 'all', search: '  YOG ' }, NOW).map(f => f.name)).toEqual(['Yogurt'])
+  })
+  it('search vuota = nessun filtro', () => {
+    expect(filterFoods(foods, { status: 'all', search: '   ' }, NOW)).toHaveLength(5)
+  })
+  it('combina filtri: categoria + stato', () => {
+    const names = filterFoods(foods, { status: 'expiring_soon', category_id: 'c1' }, NOW).map(f => f.name).sort()
+    expect(names).toEqual(['Latte', 'Yogurt'])
+  })
+})

--- a/src/lib/foodFilters.ts
+++ b/src/lib/foodFilters.ts
@@ -20,3 +20,24 @@ export function filterFoods(foods: Food[], filters: FilterParams, now: Date = ne
     return true
   })
 }
+
+/** Ordina (copia) replicando l'ordinamento server-side; null in fondo. */
+export function sortFoods(
+  foods: Food[],
+  sortBy: FilterParams['sortBy'] = 'expiry_date',
+  sortOrder: FilterParams['sortOrder'] = 'asc',
+): Food[] {
+  const key = sortBy ?? 'expiry_date'
+  const dir = sortOrder === 'desc' ? -1 : 1
+  return [...foods].sort((a, b) => {
+    const av = a[key]
+    const bv = b[key]
+    if (av == null && bv == null) return 0
+    if (av == null) return 1
+    if (bv == null) return -1
+    const cmp = key === 'name'
+      ? av.localeCompare(bv, 'it', { sensitivity: 'base' })
+      : av < bv ? -1 : av > bv ? 1 : 0
+    return cmp * dir
+  })
+}

--- a/src/lib/foodFilters.ts
+++ b/src/lib/foodFilters.ts
@@ -21,21 +21,18 @@ export function filterFoods(foods: Food[], filters: FilterParams, now: Date = ne
   })
 }
 
-/** Ordina (copia) replicando l'ordinamento server-side; null in fondo. */
+/** Ordina (copia) lato client: collazione italiana per `name`, ordinamento
+ *  lessicografico per date/id ISO. Tutti i campi ordinabili sono `string`. */
 export function sortFoods(
   foods: Food[],
   sortBy: FilterParams['sortBy'] = 'expiry_date',
   sortOrder: FilterParams['sortOrder'] = 'asc',
 ): Food[] {
-  const key = sortBy ?? 'expiry_date'
   const dir = sortOrder === 'desc' ? -1 : 1
   return [...foods].sort((a, b) => {
-    const av = a[key]
-    const bv = b[key]
-    if (av == null && bv == null) return 0
-    if (av == null) return 1
-    if (bv == null) return -1
-    const cmp = key === 'name'
+    const av = a[sortBy]
+    const bv = b[sortBy]
+    const cmp = sortBy === 'name'
       ? av.localeCompare(bv, 'it', { sensitivity: 'base' })
       : av < bv ? -1 : av > bv ? 1 : 0
     return cmp * dir

--- a/src/lib/foodFilters.ts
+++ b/src/lib/foodFilters.ts
@@ -1,0 +1,22 @@
+// Filtro/ordinamento client-side degli alimenti, fonte unica @/lib/expiry.
+// Replica la semantica del vecchio filtro server-side di getFoods, ma opera
+// sui dati già in cache → funziona offline e resta coerente coi conteggi.
+import type { Food, FilterParams } from '@/lib/foods'
+import { getExpiryStatus, isExpiringSoon, isExpired } from '@/lib/expiry'
+
+/** Applica categoria, posizione, ricerca (substring case-insensitive) e stato. */
+export function filterFoods(foods: Food[], filters: FilterParams, now: Date = new Date()): Food[] {
+  const search = filters.search?.trim().toLowerCase()
+  return foods.filter((food) => {
+    if (filters.category_id && food.category_id !== filters.category_id) return false
+    if (filters.storage_location && food.storage_location !== filters.storage_location) return false
+    if (search && !food.name.toLowerCase().includes(search)) return false
+    if (filters.status && filters.status !== 'all') {
+      const status = getExpiryStatus(food.expiry_date, now)
+      if (filters.status === 'expired') return isExpired(status)
+      if (filters.status === 'expiring_soon') return isExpiringSoon(status)
+      if (filters.status === 'active') return !isExpired(status)
+    }
+    return true
+  })
+}

--- a/src/lib/foodFilters.ts
+++ b/src/lib/foodFilters.ts
@@ -41,3 +41,26 @@ export function sortFoods(
     return cmp * dir
   })
 }
+
+export interface DashboardData {
+  foods: Food[]
+  stats: { total: number; expiringSoon: number; expired: number }
+}
+
+/**
+ * Deriva lista mostrata + conteggi card dalla stessa lista in cache.
+ * I conteggi riflettono i filtri categoria/posizione/ricerca attivi (non lo stato);
+ * la lista applica anche lo stato e l'ordinamento.
+ */
+export function deriveDashboardData(allFoods: Food[], filters: FilterParams, now: Date = new Date()): DashboardData {
+  const scoped = filterFoods(allFoods, { ...filters, status: 'all' }, now)
+  let expiringSoon = 0
+  let expired = 0
+  for (const food of scoped) {
+    const status = getExpiryStatus(food.expiry_date, now)
+    if (isExpiringSoon(status)) expiringSoon++
+    if (isExpired(status)) expired++
+  }
+  const foods = sortFoods(filterFoods(scoped, { status: filters.status }, now), filters.sortBy, filters.sortOrder)
+  return { foods, stats: { total: scoped.length, expiringSoon, expired } }
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -22,7 +22,7 @@ const WeekView = lazy(() => import('../components/foods/WeekView').then(m => ({ 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { Button } from '../components/ui/button'
 import type { Food, FilterParams } from '@/lib/foods'
-import { getExpiryStatus, isExpired, isExpiringSoon } from '@/lib/expiry'
+import { deriveDashboardData } from '@/lib/foodFilters'
 import { cn } from '@/lib/utils'
 
 /**
@@ -96,16 +96,16 @@ export function DashboardPage() {
     }
   }, [filters, debouncedSearch])
 
-  // Filters for stats: same as current filters but always status='all'
-  // When status is already 'all', React Query reuses the same cache entry (no extra request)
-  const statsFilters = useMemo<FilterParams>(() => ({
-    ...debouncedFilters,
-    status: 'all',
-  }), [debouncedFilters])
+  // Una sola query non filtrata: chiave di cache stabile, caricata a ogni visita
+  // online → persistita e disponibile offline. Filtro/ordinamento/conteggi sono
+  // derivati client-side dagli stessi dati (vedi @/lib/foodFilters).
+  const { data: allFoods = [], isLoading: foodsLoading } = useFoods()
 
-  // Fetch data with filters
-  const { data: foods = [], isLoading: foodsLoading } = useFoods(debouncedFilters)
-  const { data: allFoods = [] } = useFoods(statsFilters)
+  const { foods, stats } = useMemo(
+    () => deriveDashboardData(allFoods, debouncedFilters),
+    [allFoods, debouncedFilters],
+  )
+
   const { data: categories = [] } = useCategories()
 
   // Food CRUD dialogs and handlers
@@ -174,25 +174,6 @@ export function DashboardPage() {
     // Scroll to foods section on mobile
     window.scrollTo({ top: 400, behavior: 'smooth' })
   }
-
-  // Calculate stats from the canonical expiry classification (see @/lib/expiry)
-  const stats = useMemo(() => {
-    const now = new Date()
-    let expiringSoon = 0
-    let expired = 0
-
-    for (const food of allFoods) {
-      const status = getExpiryStatus(food.expiry_date, now)
-      if (isExpiringSoon(status)) expiringSoon++
-      if (isExpired(status)) expired++
-    }
-
-    return {
-      total: allFoods.length,
-      expiringSoon,
-      expired,
-    }
-  }, [allFoods])
 
   // Get category for a food item
   const getCategoryForFood = (food: Food) => {


### PR DESCRIPTION
## Contesto
Refs #44. Offline, le card mostravano "In scadenza: N" ma il filtro dava 0 risultati: filtro server-side (`getFoods`) con chiavi di cache per-filtro non disponibili offline, mentre il conteggio era calcolato client-side.

## Soluzione
Filtro/ordinamento **interamente client-side** da una singola lista in cache, con `@/lib/expiry` come fonte unica.

- **Nuovo `src/lib/foodFilters.ts`** (puro, testato): `filterFoods` (categoria/posizione/ricerca/stato, parità con il filtro server-side), `sortFoods`, `deriveDashboardData` (→ `{ foods, stats }` dalla stessa lista).
- **`DashboardPage`**: una sola query `useFoods()` (chiave di cache stabile, persistita offline) + derivazione client-side. Rimosse la query duplicata e il calcolo stats inline.
- Conteggio card e lista derivano dagli **stessi dati** → sempre coerenti, online e offline.

## Test (TDD)
`src/lib/__tests__/foodFilters.test.ts`: business rule degli stati + confini (−1/0/2/7/8 giorni), categoria/posizione/ricerca, ordinamento asc/desc, e **regressione #44** (conteggio == lunghezza lista per quello stato).

## Verifica
- `tsc -b` 0 · `lint` 0 errori · `npm test` **174 verdi** (incl. nuovo modulo) · `build` ok (`dist/sw.js`, 63 entry precache).
- Spec review + code-quality review superate per modulo e wiring.

## Documentazione
- entro: `CHANGELOG.md` (Unreleased/Fixed), `docs/guides/USER_GUIDE.md`; docs privati aggiornati su disco (gitignored).
- entro-family: `conventions/expiry-status-ssot.md`, `core/expiry-status.md`, `log.md` (commit separato locale).

## ⚠️ Gate prima del merge → produzione
Il test offline definitivo richiede la PWA installata su iPhone (origine di produzione): si testa **dopo il merge su `main`**. L'issue #44 verrà chiusa dopo l'esito positivo. `git revert` pronto in caso di regressione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)