### PR TITLE
feat: storage persistente + compatibilità di piattaforma verificata su MDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Added
+- **Storage persistente**: all'avvio l'app chiede al browser di esentare la cache offline (IndexedDB) dalla cancellazione automatica via `navigator.storage.persist()` (supportato su Chrome 55+, Firefox 57+, Safari/iOS 15.2+). Mitiga la perdita dei dati offline dovuta alla cancellazione ~7 giorni di iOS per lo storage non-persistente. Best-effort: su iOS Safari la concessione è euristica, installare l'app in schermata Home resta la garanzia migliore.
+
+### Documentation
+- Allineate alla realtà (verifica su MDN Browser Compatibility Data) le assunzioni di compatibilità di piattaforma in codice e documentazione: feedback aptico non attivo su Firefox (desktop rimosso in v129, Android lo no-op pur esponendo l'API), opzione `vibrate` delle notifiche limitata ad Android Chromium, detection PWA iOS che dipende da `navigator.standalone` (WebKit riporta `display-mode: fullscreen` per le PWA installate, webkit#264218), push iOS solo da 16.4+ con app in Home.
+
 ## [1.7.5] - 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Il progetto copre l'intero ciclo di vita di un'applicazione web: dal design del 
 - **Push notifications** — Avvisi giornalieri per alimenti in scadenza, personalizzabili per anticipo, ore silenziose e limite giornaliero
 - **Vista calendario** — Agenda verticale dei prossimi 7 giorni: l'intera settimana a colpo d'occhio, ogni giorno con conteggio e urgenza delle scadenze
 - **Swipe gestures** — Swipe destro per modificare, sinistro per eliminare (mobile)
-- **Feedback aptico** — Vibrazione tattile su swipe, creazione, modifica ed eliminazione alimenti (su Android e browser che espongono la Vibration API; non disponibile su iOS/Safari)
+- **Feedback aptico** — Vibrazione tattile su swipe, creazione, modifica ed eliminazione alimenti (su Android con browser basati su Chromium che implementano la Vibration API; non disponibile su iOS/Safari, e Firefox non la attiva)
 - **Dark mode** — Light, dark e automatico (segue il sistema)
 - **PWA installabile** — Installabile da browser su iOS e Android con esperienza offline nativa
 - **GDPR compliant** — Export dati personali (Art. 20), cancellazione account (Art. 17), Privacy Policy e T&C integrati

--- a/src/lib/__tests__/queryPersister.test.ts
+++ b/src/lib/__tests__/queryPersister.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+// Reload the module with a fresh navigator each case so feature detection
+// reflects the stubbed StorageManager.
+async function loadPersister() {
+  vi.resetModules()
+  return import('../queryPersister')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('requestPersistentStorage', () => {
+  it('ritorna false quando StorageManager.persist non esiste (es. browser vecchio)', async () => {
+    vi.stubGlobal('navigator', {} as Partial<Navigator>)
+    const { requestPersistentStorage } = await loadPersister()
+    expect(await requestPersistentStorage()).toBe(false)
+  })
+
+  it('ritorna false quando navigator.storage esiste ma senza persist()', async () => {
+    vi.stubGlobal('navigator', { storage: {} } as unknown as Navigator)
+    const { requestPersistentStorage } = await loadPersister()
+    expect(await requestPersistentStorage()).toBe(false)
+  })
+
+  it('ritorna true quando il browser concede la persistenza', async () => {
+    const persist = vi.fn().mockResolvedValue(true)
+    vi.stubGlobal('navigator', { storage: { persist } } as unknown as Navigator)
+    const { requestPersistentStorage } = await loadPersister()
+    expect(await requestPersistentStorage()).toBe(true)
+    expect(persist).toHaveBeenCalledOnce()
+  })
+
+  it('ritorna false quando il browser nega (es. iOS Safari non installato)', async () => {
+    vi.stubGlobal('navigator', {
+      storage: { persist: vi.fn().mockResolvedValue(false) },
+    } as unknown as Navigator)
+    const { requestPersistentStorage } = await loadPersister()
+    expect(await requestPersistentStorage()).toBe(false)
+  })
+
+  it('non lancia se persist() rifiuta: ritorna false', async () => {
+    vi.stubGlobal('navigator', {
+      storage: { persist: vi.fn().mockRejectedValue(new Error('boom')) },
+    } as unknown as Navigator)
+    const { requestPersistentStorage } = await loadPersister()
+    expect(await requestPersistentStorage()).toBe(false)
+  })
+})

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -11,12 +11,23 @@ let enabledCache: boolean | null = null
  * Check if haptic feedback can actually fire on this device.
  *
  * Only the standard Vibration API (`navigator.vibrate`) delivers reliable,
- * programmatic haptics — that means Android (Chrome/Firefox/Edge). iOS/WebKit
- * does NOT implement `navigator.vibrate`, and the `<input type="checkbox" switch>`
- * trick only vibrates on a real user toggle of the control, never on a
- * programmatic `trigger()`. So we report support strictly where the Vibration
- * API exists; everywhere else (e.g. iPhone, Safari) the "Feedback aptico"
- * setting stays hidden instead of promising feedback we can't deliver.
+ * programmatic haptics. Per MDN browser-compat data (verified 2026-06-17,
+ * `api.Navigator.vibrate`) that means Chromium-based Android — Chrome, Edge,
+ * Opera, Samsung Internet. Gaps the bare `typeof` check below cannot see:
+ *   - iOS/WebKit (every iOS browser) never implements it.
+ *   - Firefox desktop removed `navigator.vibrate` in v129 → reads as
+ *     unsupported here, correctly.
+ *   - Firefox Android still EXPOSES `navigator.vibrate` but the engine no-ops
+ *     it (disabled for abuse, bugzil.la/1653318): it returns `true` yet nothing
+ *     vibrates. So on Firefox Android this gate reports "supported" and the
+ *     "Feedback aptico" setting shows, but triggers stay silent. Accepted: the
+ *     failure is harmless and UA-sniffing Firefox is more fragile than the gap.
+ *
+ * The `<input type="checkbox" switch>` trick in `web-haptics` only vibrates on a
+ * real user toggle, never on a programmatic `trigger()`, so it buys nothing. We
+ * report support strictly where the Vibration API exists; on iOS/Safari the
+ * "Feedback aptico" setting stays hidden instead of promising feedback we can't
+ * deliver.
  */
 function canHaptics(): boolean {
   if (typeof navigator === 'undefined') return false

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -36,6 +36,17 @@ export function isPushSupported(): boolean {
   return 'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window
 }
 
+/**
+ * Rileva se l'app gira come PWA installata.
+ *
+ * Il ramo `navigator.standalone` è load-bearing su iOS, non un semplice
+ * fallback: per una PWA installata con manifest `display: standalone`, iOS
+ * WebKit riporta `display-mode: fullscreen` (NON `standalone`) in matchMedia
+ * (webkit bug 264218; MDN `css.at-rules.media.display-mode`, verificato
+ * 2026-06-17). Senza `navigator.standalone` il guard push iOS qui sotto
+ * tratterebbe gli iPhone installati come "non installati" e non li farebbe mai
+ * iscrivere. Mantenere entrambi i rami.
+ */
 export function isPWAInstalled(): boolean {
   return window.matchMedia('(display-mode: standalone)').matches
     || (navigator as { standalone?: boolean }).standalone === true

--- a/src/lib/queryPersister.ts
+++ b/src/lib/queryPersister.ts
@@ -29,3 +29,23 @@ export function createIDBPersister(): Persister {
 export async function clearPersistedCache(): Promise<void> {
   await del(IDB_KEY)
 }
+
+/**
+ * Ask the browser to exempt our IndexedDB cache from automatic eviction.
+ *
+ * Verified support (MDN `api.StorageManager.persist`, 2026-06-17):
+ * Chrome 55+, Firefox 57+, Safari/iOS 15.2+. Best-effort by design: iOS Safari
+ * grants persistence heuristically (e.g. once the PWA is installed), so a
+ * `false` result is normal — the WebKit ~7-day eviction of non-persistent
+ * storage may still apply to in-browser (non-installed) use. Never throws.
+ *
+ * @returns whether persistent storage was granted
+ */
+export async function requestPersistentStorage(): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.persist) return false
+  try {
+    return await navigator.storage.persist()
+  } catch {
+    return false
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, onlineManager } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
-import { createIDBPersister } from './lib/queryPersister'
+import { createIDBPersister, requestPersistentStorage } from './lib/queryPersister'
 import { registerMutationDefaults } from './lib/mutationDefaults'
 import './index.css'
 import App from './App.tsx'
@@ -39,6 +39,11 @@ registerMutationDefaults(queryClient)
 
 // IndexedDB persister for cache + mutations
 const persister = createIDBPersister()
+
+// Chiede al browser di esentare la cache IndexedDB dall'eviction (best-effort;
+// vedi requestPersistentStorage per i limiti di piattaforma — in particolare la
+// cancellazione ~7 giorni di iOS per lo storage non-persistente).
+void requestPersistentStorage()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -87,6 +87,10 @@ self.addEventListener('push', (event: PushEvent) => {
     badge: payload.badge ?? '/icons/favicon-32x32.png',
     tag: payload.tag ?? 'entro-expiry',
     data: payload.data ?? { url: '/' },
+    // `vibrate` è sperimentale e onorato solo su Android Chromium
+    // (api.Notification.vibrate, verificato 2026-06-17); iOS/Firefox/Safari e
+    // tutte le WebView lo ignorano — iOS suona il proprio haptic di notifica.
+    // Innocuo dove non supportato.
     vibrate: [100, 50, 200],
     requireInteraction: true,
   }


### PR DESCRIPTION
## Sintesi

Audit delle Web API platform-sensitive di Entro con le assunzioni interne verificate contro i **MDN Browser Compatibility Data** (via MDN MCP Server). Allinea codice e doc pubblici alla realtà verificata e aggiunge una mitigazione concreta all'eviction dello storage su iOS.

## Cosa cambia

### Funzionalità (unico cambio di comportamento)
- **`requestPersistentStorage()`** (`src/lib/queryPersister.ts`), chiamata all'avvio in `main.tsx`: chiede al browser di esentare la cache offline (IndexedDB) dalla cancellazione automatica via `navigator.storage.persist()`. Verificato supportato su Chrome 55+, Firefox 57+, **Safari/iOS 15.2+**. Best-effort, guardato, non lancia mai. Mitiga la perdita dati dovuta alla cancellazione ~7 giorni di iOS per lo storage non-persistente.

### Allineamento alla verità (commenti + doc, nessun cambio di logica)
- **haptics** (`src/lib/haptics.ts`, `README.md`): Firefox non attiva la vibrazione — desktop ha rimosso `navigator.vibrate` in v129, Android la espone ma il motore la no-op (bugzil.la/1653318). Gate volutamente lasco (no UA-sniffing).
- **`isPWAInstalled()`** (`src/lib/pushNotifications.ts`): documentato che `navigator.standalone` è **load-bearing** su iOS — per una PWA installata WebKit riporta `display-mode: fullscreen`, non `standalone` (webkit#264218). Rimuoverlo romperebbe la subscribe push su iPhone.
- **`Notification.vibrate`** (`src/sw.ts`): sperimentale, onorata solo su Android Chromium; ignorata altrove (innocua).

## Test
- +5 test per `requestPersistentStorage` (assenza API, concesso, negato, errore).
- **179/179 test verdi**, `tsc -b` pulito.

## Note
- I doc interni di dettaglio (`docs/development/CROSS_BROWSER_TESTING.md` con la matrice di compatibilità verificata, `docs/private/FEATURES.md`) sono **gitignored** per la separazione showcase/open-source: aggiornati in locale, non inclusi in questa PR.
- Follow-up tracciato in #47: migrare `isIOS()` da `navigator.platform` (deprecato) a `userAgentData`/`maxTouchPoints`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)