### PR TITLE
fix: rimuove navigator.platform (deprecato) da isIOS() (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Fixed
+- `isIOS()` non usa più `navigator.platform` (API legacy, segnalata come deprecata da TypeScript): la detection iOS ora si basa su `userAgent` + `navigator.maxTouchPoints`. Verifica MDN: `navigator.userAgentData` è assente su Safari/iOS (quindi inutile per rilevare iOS), `maxTouchPoints` è supportato da iOS/Safari 13+. Riconoscimento di iPhone e iPadOS (che si presenta come "Macintosh") invariato, distinto da un Mac reale tramite il touch. (#47)
+
 ### Added
 - **Storage persistente**: all'avvio l'app chiede al browser di esentare la cache offline (IndexedDB) dalla cancellazione automatica via `navigator.storage.persist()` (supportato su Chrome 55+, Firefox 57+, Safari/iOS 15.2+). Mitiga la perdita dei dati offline dovuta alla cancellazione ~7 giorni di iOS per lo storage non-persistente. Best-effort: su iOS Safari la concessione è euristica, installare l'app in schermata Home resta la garanzia migliore.
 

--- a/src/lib/__tests__/pushNotifications.test.ts
+++ b/src/lib/__tests__/pushNotifications.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+// isIOS() needs only `navigator`; mock the supabase client so importing the
+// module doesn't construct a real client (isIOS doesn't touch supabase).
+vi.mock('../supabase', () => ({ supabase: {} }))
+
+const IPHONE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+// iPadOS Safari reports the SAME "Macintosh" userAgent as a desktop Mac —
+// only the presence of touch points distinguishes the two.
+const MAC_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15'
+
+async function loadModule(nav: Partial<Navigator>) {
+  vi.resetModules()
+  vi.stubGlobal('navigator', nav)
+  return import('../pushNotifications')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('isIOS', () => {
+  it('riconosce iPadOS che si presenta come Macintosh (touch presente) senza usare navigator.platform', async () => {
+    const m = await loadModule({ userAgent: MAC_UA, maxTouchPoints: 5 } as Partial<Navigator>)
+    expect(m.isIOS()).toBe(true)
+  })
+
+  it('riconosce iPhone dallo userAgent', async () => {
+    const m = await loadModule({ userAgent: IPHONE_UA, maxTouchPoints: 5 } as Partial<Navigator>)
+    expect(m.isIOS()).toBe(true)
+  })
+
+  it('NON considera iOS un Mac desktop reale (stesso UA Macintosh, ma nessun touch)', async () => {
+    const m = await loadModule({ userAgent: MAC_UA, maxTouchPoints: 0 } as Partial<Navigator>)
+    expect(m.isIOS()).toBe(false)
+  })
+})

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -53,8 +53,13 @@ export function isPWAInstalled(): boolean {
 }
 
 export function isIOS(): boolean {
-  return /iPad|iPhone|iPod/.test(navigator.userAgent)
-    || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  const ua = navigator.userAgent
+  if (/iPad|iPhone|iPod/.test(ua)) return true
+  // iPadOS Safari si presenta come "Macintosh": lo distinguiamo da un Mac reale
+  // tramite il touch (i Mac non hanno touchscreen). Evita `navigator.platform`,
+  // deprecato (issue #47). Verifica MDN 2026-06-17: `userAgentData` è assente su
+  // Safari/iOS, `maxTouchPoints` è supportato da iOS/Safari 13+.
+  return /Macintosh/.test(ua) && navigator.maxTouchPoints > 1
 }
 
 export function getPermissionState(): NotificationPermission {


### PR DESCRIPTION
Risolve #47.

## Problema
`isIOS()` usava `navigator.platform` (API legacy, segnalata `@deprecated` da TypeScript → warning TS6385) per rilevare gli iPad che si presentano come `Macintosh`.

## Soluzione
Detection iOS basata su `userAgent` + `navigator.maxTouchPoints`, senza API deprecate.

Verifica su MDN Browser Compatibility Data (2026-06-17):
- `navigator.userAgentData` è **assente su Safari/iOS/Firefox** → inutile per rilevare iOS (tutti i browser iOS sono WebKit). Scartato.
- `navigator.maxTouchPoints` è standard, supportato da **iOS/Safari 13+**.

```ts
export function isIOS(): boolean {
  const ua = navigator.userAgent
  if (/iPad|iPhone|iPod/.test(ua)) return true
  // iPadOS si presenta come "Macintosh"; il touch lo distingue da un Mac reale.
  return /Macintosh/.test(ua) && navigator.maxTouchPoints > 1
}
```

## Test (TDD)
Nuovo `src/lib/__tests__/pushNotifications.test.ts`, i 3 casi dei criteri di accettazione:
- iPhone (UA) → iOS ✅
- iPadOS che si presenta come Macintosh + touch → iOS ✅
- Mac desktop reale (stesso UA, nessun touch) → non iOS ✅

**182/182 test verdi**, `tsc -b` pulito, nessun warning TS6385.

## Note
- Nessun cambiamento di comportamento osservabile: il guard push iOS continua a funzionare identico.
- Doc interni (gitignored) e la convention `entro-family` aggiornati separatamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)