### PR TITLE
feat(push): recupero subscription persa (iOS) con nudge in-app + handler SW MDN

### DIFF
--- a/src/components/pwa/NotificationPrompt.tsx
+++ b/src/components/pwa/NotificationPrompt.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react'
-import { Bell, X } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
+import { Bell, BellRing, X } from 'lucide-react'
 import { Button } from '../ui/button'
-import { isPushSupported, getPermissionState } from '@/lib/pushNotifications'
 import { usePushSubscription } from '@/hooks/usePushSubscription'
 
 const DISMISSED_KEY = 'entro_notification_prompt_dismissed'
@@ -13,47 +12,86 @@ interface NotificationPromptProps {
 }
 
 export function NotificationPrompt({ foodCount }: NotificationPromptProps) {
-  const [dismissed, setDismissed] = useState(
+  const { status, subscribe, isLoading } = usePushSubscription()
+  // First-time opt-in: permanently dismissible (localStorage).
+  const [upsellDismissed, setUpsellDismissed] = useState(
     () => localStorage.getItem(DISMISSED_KEY) === 'true'
   )
-  const { status, subscribe, isLoading } = usePushSubscription()
+  // Lost subscription: a malfunction, so only dismissible for the session
+  // (in-memory) — it must resurface on the next visit until actually fixed.
+  const [lostDismissed, setLostDismissed] = useState(false)
 
-  const shouldHide = dismissed
-    || !isPushSupported()
-    || getPermissionState() !== 'default'
-    || foodCount < MIN_FOODS_FOR_PROMPT
+  const pending = isLoading || status === 'loading'
 
-  if (shouldHide) return null
-
-  function dismiss(): void {
-    localStorage.setItem(DISMISSED_KEY, 'true')
-    setDismissed(true)
+  // Subscription silently lost (e.g. iOS invalidation): nudge to re-enable.
+  // Shown regardless of foodCount and independent of the upsell dismissal.
+  if (status === 'lost' && !lostDismissed) {
+    return (
+      <PromptBanner
+        tone="warning"
+        icon={<BellRing className="h-5 w-5 text-warning mt-0.5 shrink-0" />}
+        message="Le notifiche si sono disattivate. Riattivale per non perdere le scadenze."
+        onDismiss={() => setLostDismissed(true)}
+      >
+        <Button size="touch" onClick={() => subscribe()} disabled={pending}>
+          {pending ? 'Attivazione...' : 'Riattiva'}
+        </Button>
+      </PromptBanner>
+    )
   }
 
-  async function handleActivate(): Promise<void> {
-    await subscribe()
-    // Hide the prompt regardless of outcome -- on denial the settings page will show the status
-    dismiss()
+  // First-time opt-in: only once the user has enough foods to care about.
+  if (status === 'prompt' && !upsellDismissed && foodCount >= MIN_FOODS_FOR_PROMPT) {
+    const dismiss = (): void => {
+      localStorage.setItem(DISMISSED_KEY, 'true')
+      setUpsellDismissed(true)
+    }
+    const activate = async (): Promise<void> => {
+      await subscribe()
+      // Hide regardless of outcome -- on denial the settings page shows the status.
+      dismiss()
+    }
+    return (
+      <PromptBanner
+        tone="primary"
+        icon={<Bell className="h-5 w-5 text-primary mt-0.5 shrink-0" />}
+        message="Vuoi ricevere notifiche quando i tuoi alimenti stanno per scadere?"
+        onDismiss={dismiss}
+      >
+        <Button size="touch" onClick={activate} disabled={pending}>
+          {pending ? 'Attivazione...' : 'Attiva'}
+        </Button>
+        <Button size="touch" variant="ghost" onClick={dismiss}>
+          Non ora
+        </Button>
+      </PromptBanner>
+    )
   }
 
+  return null
+}
+
+interface PromptBannerProps {
+  tone: 'primary' | 'warning'
+  icon: ReactNode
+  message: string
+  onDismiss: () => void
+  children: ReactNode
+}
+
+function PromptBanner({ tone, icon, message, onDismiss, children }: PromptBannerProps) {
+  const toneClass = tone === 'warning'
+    ? 'bg-warning/10 border-warning/30'
+    : 'bg-primary/5 border-primary/20'
   return (
-    <div className="relative flex items-start gap-3 p-4 bg-primary/5 border border-primary/20 rounded-lg">
-      <Bell className="h-5 w-5 text-primary mt-0.5 shrink-0" />
+    <div className={`relative flex items-start gap-3 p-4 border rounded-lg ${toneClass}`}>
+      {icon}
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium">
-          Vuoi ricevere notifiche quando i tuoi alimenti stanno per scadere?
-        </p>
-        <div className="flex gap-2 mt-3">
-          <Button size="touch" onClick={handleActivate} disabled={isLoading || status === 'loading'}>
-            {isLoading ? 'Attivazione...' : 'Attiva'}
-          </Button>
-          <Button size="touch" variant="ghost" onClick={dismiss}>
-            Non ora
-          </Button>
-        </div>
+        <p className="text-sm font-medium">{message}</p>
+        <div className="flex gap-2 mt-3">{children}</div>
       </div>
       <button
-        onClick={dismiss}
+        onClick={onDismiss}
         className="-mr-2 -mt-2 flex h-11 w-11 shrink-0 items-center justify-center text-muted-foreground hover:text-foreground"
         aria-label="Chiudi"
       >

--- a/src/components/pwa/__tests__/NotificationPrompt.test.tsx
+++ b/src/components/pwa/__tests__/NotificationPrompt.test.tsx
@@ -3,45 +3,49 @@ import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { NotificationPrompt } from '../NotificationPrompt'
 
-const { mockIsSupported, mockPermission, mockSubscribe } = vi.hoisted(() => ({
-  mockIsSupported: vi.fn(),
-  mockPermission: vi.fn(),
-  mockSubscribe: vi.fn(),
+const { subscribe, pushState } = vi.hoisted(() => ({
+  subscribe: vi.fn(),
+  pushState: { status: 'prompt' as string, isLoading: false },
 }))
 
-vi.mock('@/lib/pushNotifications', () => ({
-  isPushSupported: () => mockIsSupported(),
-  getPermissionState: () => mockPermission(),
-}))
 vi.mock('@/hooks/usePushSubscription', () => ({
-  usePushSubscription: () => ({ status: 'prompt', subscribe: mockSubscribe, isLoading: false }),
+  usePushSubscription: () => ({ status: pushState.status, isLoading: pushState.isLoading, subscribe }),
 }))
+
+const DISMISSED_KEY = 'entro_notification_prompt_dismissed'
 
 beforeEach(() => {
   localStorage.clear()
-  mockIsSupported.mockReturnValue(true)
-  mockPermission.mockReturnValue('default')
-  mockSubscribe.mockResolvedValue(undefined)
+  pushState.status = 'prompt'
+  pushState.isLoading = false
+  subscribe.mockClear()
+  subscribe.mockResolvedValue(undefined)
 })
 
 afterEach(cleanup)
 
-describe('NotificationPrompt', () => {
+describe('NotificationPrompt — upsell (status "prompt")', () => {
   it('stays hidden below the food threshold (business rule)', () => {
     const { container } = render(<NotificationPrompt foodCount={2} />)
     expect(container.firstChild).toBeNull()
   })
 
-  it('stays hidden when push is unsupported', () => {
-    mockIsSupported.mockReturnValue(false)
-    const { container } = render(<NotificationPrompt foodCount={10} />)
+  it('shows the opt-in above the threshold', () => {
+    render(<NotificationPrompt foodCount={3} />)
+    expect(screen.getByRole('button', { name: 'Attiva' })).toBeTruthy()
+  })
+
+  it('dismisses and persists the choice permanently when "Non ora" is clicked', () => {
+    const { container } = render(<NotificationPrompt foodCount={3} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Non ora' }))
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe('true')
     expect(container.firstChild).toBeNull()
   })
 
-  it('stays hidden once the permission is no longer "default"', () => {
-    mockPermission.mockReturnValue('granted')
-    const { container } = render(<NotificationPrompt foodCount={10} />)
-    expect(container.firstChild).toBeNull()
+  it('subscribes when "Attiva" is clicked', () => {
+    render(<NotificationPrompt foodCount={3} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Attiva' }))
+    expect(subscribe).toHaveBeenCalledTimes(1)
   })
 
   it('renders 44px touch targets for the actions and the dismiss control', () => {
@@ -51,17 +55,51 @@ describe('NotificationPrompt', () => {
     expect(dismiss.className).toContain('h-11')
     expect(dismiss.className).toContain('w-11')
   })
+})
 
-  it('dismisses and persists the choice when "Non ora" is clicked', () => {
-    const { container } = render(<NotificationPrompt foodCount={3} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Non ora' }))
-    expect(localStorage.getItem('entro_notification_prompt_dismissed')).toBe('true')
+describe('NotificationPrompt — healthy / unsupported', () => {
+  it('stays hidden when already subscribed', () => {
+    pushState.status = 'subscribed'
+    const { container } = render(<NotificationPrompt foodCount={10} />)
     expect(container.firstChild).toBeNull()
   })
 
-  it('subscribes when "Attiva" is clicked', () => {
-    render(<NotificationPrompt foodCount={3} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Attiva' }))
-    expect(mockSubscribe).toHaveBeenCalledTimes(1)
+  it('stays hidden when push is unsupported', () => {
+    pushState.status = 'unsupported'
+    const { container } = render(<NotificationPrompt foodCount={10} />)
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('NotificationPrompt — subscription persa (status "lost")', () => {
+  it('shows the re-enable nudge even with zero foods (always visible)', () => {
+    pushState.status = 'lost'
+    render(<NotificationPrompt foodCount={0} />)
+    expect(screen.getByText(/si sono disattivate/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Riattiva' })).toBeTruthy()
+  })
+
+  it('re-subscribes when "Riattiva" is clicked', () => {
+    pushState.status = 'lost'
+    render(<NotificationPrompt foodCount={0} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Riattiva' }))
+    expect(subscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismiss is per-session: hides without persisting to localStorage', () => {
+    pushState.status = 'lost'
+    const { container } = render(<NotificationPrompt foodCount={0} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Chiudi' }))
+    expect(container.firstChild).toBeNull()
+    expect(localStorage.getItem(DISMISSED_KEY)).toBeNull()
+  })
+
+  it('a malfunction cannot be silenced by the permanent upsell dismissal (safeguard)', () => {
+    // User previously dismissed the first-time opt-in forever...
+    localStorage.setItem(DISMISSED_KEY, 'true')
+    pushState.status = 'lost'
+    render(<NotificationPrompt foodCount={0} />)
+    // ...but a genuinely broken subscription must still surface.
+    expect(screen.getByRole('button', { name: 'Riattiva' })).toBeTruthy()
   })
 })

--- a/src/components/settings/NotificationSettings.tsx
+++ b/src/components/settings/NotificationSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
 import { Button } from '../ui/button'
 import { Bell, BellOff, Smartphone } from 'lucide-react'
-import { usePushSubscription } from '@/hooks/usePushSubscription'
+import { usePushSubscription, type PushStatus } from '@/hooks/usePushSubscription'
 import { useNotificationPreferences, useUpdateNotificationPreferences } from '@/hooks/useNotificationPreferences'
 
 const INTERVAL_OPTIONS = [
@@ -25,6 +25,17 @@ function getToggleButtonLabel(isLoading: boolean, isSubscribed: boolean): string
   return 'Attiva'
 }
 
+function getToggleHintText(status: PushStatus): string {
+  switch (status) {
+    case 'subscribed':
+      return 'Riceverai avvisi sulle scadenze'
+    case 'lost':
+      return 'Le notifiche si sono disattivate, riattivale'
+    default:
+      return 'Attiva per ricevere avvisi'
+  }
+}
+
 export function NotificationSettings() {
   const { status, isLoading, subscribe, unsubscribe } = usePushSubscription()
   const { data: prefs } = useNotificationPreferences()
@@ -32,7 +43,7 @@ export function NotificationSettings() {
   const [showMinIntervalHint, setShowMinIntervalHint] = useState(false)
 
   const isSubscribed = status === 'subscribed'
-  const showToggle = status === 'prompt' || status === 'subscribed' || status === 'loading'
+  const showToggle = status === 'prompt' || status === 'subscribed' || status === 'lost' || status === 'loading'
 
   function handleIntervalToggle(interval: number): void {
     if (!prefs) return
@@ -97,8 +108,11 @@ export function NotificationSettings() {
           <div className="flex items-center justify-between">
             <div>
               <p className="font-medium">Notifiche push</p>
-              <p className="text-sm text-muted-foreground" aria-live="polite">
-                {isSubscribed ? 'Riceverai avvisi sulle scadenze' : 'Attiva per ricevere avvisi'}
+              <p
+                className={`text-sm ${status === 'lost' ? 'text-warning' : 'text-muted-foreground'}`}
+                aria-live="polite"
+              >
+                {getToggleHintText(status)}
               </p>
             </div>
             <Button

--- a/src/components/settings/__tests__/NotificationSettings.test.tsx
+++ b/src/components/settings/__tests__/NotificationSettings.test.tsx
@@ -80,4 +80,13 @@ describe('NotificationSettings — toggle push', () => {
     expect(screen.getByRole('combobox', { name: 'Inizio ore silenziose' })).toBeTruthy()
     expect(screen.getByRole('combobox', { name: 'Fine ore silenziose' })).toBeTruthy()
   })
+
+  it('con subscription persa (status lost) mostra "Attiva" e avvisa che le notifiche si sono disattivate', () => {
+    prefsRef.current = basePrefs()
+    pushState.status = 'lost'
+    render(<NotificationSettings />)
+
+    expect(screen.getByRole('button', { name: 'Attiva' })).toBeTruthy()
+    expect(screen.getByText(/si sono disattivate/i)).toBeTruthy()
+  })
 })

--- a/src/hooks/__tests__/usePushSubscription.test.tsx
+++ b/src/hooks/__tests__/usePushSubscription.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+
+const {
+  mockSupported, mockIOS, mockPWA, mockPermission,
+  mockGetCurrent, mockSubscribe, mockUnsubscribe, mockSync,
+} = vi.hoisted(() => ({
+  mockSupported: vi.fn(),
+  mockIOS: vi.fn(),
+  mockPWA: vi.fn(),
+  mockPermission: vi.fn(),
+  mockGetCurrent: vi.fn(),
+  mockSubscribe: vi.fn(),
+  mockUnsubscribe: vi.fn(),
+  mockSync: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+vi.mock('@/lib/pushNotifications', () => ({
+  isPushSupported: () => mockSupported(),
+  isPWAInstalled: () => mockPWA(),
+  isIOS: () => mockIOS(),
+  getPermissionState: () => mockPermission(),
+  getCurrentSubscription: () => mockGetCurrent(),
+  subscribeToPush: () => mockSubscribe(),
+  unsubscribeFromPush: () => mockUnsubscribe(),
+  syncSubscription: () => mockSync(),
+}))
+
+import { usePushSubscription } from '../usePushSubscription'
+
+beforeEach(() => {
+  mockSupported.mockReturnValue(true)
+  mockIOS.mockReturnValue(false)
+  mockPWA.mockReturnValue(true)
+  mockPermission.mockReturnValue('granted')
+  mockGetCurrent.mockResolvedValue(null)
+  mockSubscribe.mockResolvedValue({ success: true })
+  mockUnsubscribe.mockResolvedValue({ success: true })
+  mockSync.mockResolvedValue(undefined)
+})
+
+afterEach(cleanup)
+
+describe('usePushSubscription — recupero subscription persa', () => {
+  it("segnala status 'lost' quando il permesso è granted ma la subscription è sparita", async () => {
+    // iOS invalida la subscription senza emettere pushsubscriptionchange:
+    // il permesso resta granted, ma getCurrentSubscription() ritorna null.
+    const { result } = renderHook(() => usePushSubscription())
+
+    await waitFor(() => expect(result.current.status).toBe('lost'))
+  })
+
+  it("resta 'subscribed' e ri-sincronizza quando esiste una subscription attiva", async () => {
+    mockGetCurrent.mockResolvedValue({ endpoint: 'https://web.push.apple.com/abc' })
+
+    const { result } = renderHook(() => usePushSubscription())
+
+    await waitFor(() => expect(mockSync).toHaveBeenCalledTimes(1))
+    expect(result.current.status).toBe('subscribed')
+  })
+})

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -5,7 +5,7 @@ import {
   getCurrentSubscription, subscribeToPush, unsubscribeFromPush, syncSubscription,
 } from '@/lib/pushNotifications'
 
-export type PushStatus = 'unsupported' | 'ios-not-installed' | 'prompt' | 'subscribed' | 'denied' | 'loading'
+export type PushStatus = 'unsupported' | 'ios-not-installed' | 'prompt' | 'subscribed' | 'lost' | 'denied' | 'loading'
 
 function getInitialStatus(): PushStatus {
   if (!isPushSupported()) return 'unsupported'
@@ -22,14 +22,17 @@ export function usePushSubscription() {
 
   // Refine status by checking actual subscription (async, non-blocking)
   // If subscribed, silently re-register to ensure server has the current endpoint
-  // (handles pushsubscriptionchange events that fired while no window was open)
+  // (handles pushsubscriptionchange events that fired while no window was open).
+  // If permission is granted but no subscription exists, it was silently lost
+  // (e.g. iOS invalidates it without firing pushsubscriptionchange) → 'lost',
+  // which surfaces a re-enable nudge rather than the first-time upsell ('prompt').
   useEffect(() => {
     if (status !== 'subscribed') return
     let cancelled = false
     getCurrentSubscription().then((sub) => {
       if (cancelled) return
       if (!sub) {
-        setStatus('prompt')
+        setStatus('lost')
       } else {
         syncSubscription()
       }

--- a/src/lib/__tests__/pushResubscribe.test.ts
+++ b/src/lib/__tests__/pushResubscribe.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resubscribeOnChange } from '../pushResubscribe'
+
+function fakeClients(clients: Array<{ postMessage: ReturnType<typeof vi.fn> }>) {
+  return { matchAll: vi.fn().mockResolvedValue(clients) }
+}
+
+function makeClient() {
+  return { postMessage: vi.fn() }
+}
+
+describe('resubscribeOnChange', () => {
+  it('ri-sottoscrive con le opzioni precedenti e notifica i client aperti', async () => {
+    const options = { userVisibleOnly: true, applicationServerKey: 'KEY' }
+    const newSub = { toJSON: () => ({ endpoint: 'https://push/new' }) }
+    const pushManager = { subscribe: vi.fn().mockResolvedValue(newSub) }
+    const client = makeClient()
+    const clients = fakeClients([client])
+
+    await resubscribeOnChange(pushManager, { oldSubscription: { options, toJSON: () => ({}) } }, clients)
+
+    expect(pushManager.subscribe).toHaveBeenCalledWith(options)
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: 'PUSH_SUBSCRIPTION_CHANGED',
+      subscription: { endpoint: 'https://push/new' },
+    })
+  })
+
+  it('usa la chiave VAPID di fallback quando manca oldSubscription (caso Firefox)', async () => {
+    const newSub = { toJSON: () => ({ endpoint: 'https://push/ff' }) }
+    const pushManager = { subscribe: vi.fn().mockResolvedValue(newSub) }
+    const clients = fakeClients([])
+
+    await resubscribeOnChange(pushManager, {}, clients, 'VAPID_FALLBACK')
+
+    expect(pushManager.subscribe).toHaveBeenCalledWith({
+      userVisibleOnly: true,
+      applicationServerKey: 'VAPID_FALLBACK',
+    })
+  })
+
+  it('usa direttamente newSubscription se il browser la fornisce, senza ri-sottoscrivere', async () => {
+    const pushManager = { subscribe: vi.fn() }
+    const client = makeClient()
+    const clients = fakeClients([client])
+    const newSubscription = { toJSON: () => ({ endpoint: 'https://push/provided' }), options: {} }
+
+    await resubscribeOnChange(pushManager, { newSubscription }, clients)
+
+    expect(pushManager.subscribe).not.toHaveBeenCalled()
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: 'PUSH_SUBSCRIPTION_CHANGED',
+      subscription: { endpoint: 'https://push/provided' },
+    })
+  })
+
+  it('degrada senza lanciare quando la ri-sottoscrizione fallisce', async () => {
+    const pushManager = { subscribe: vi.fn().mockRejectedValue(new Error('denied')) }
+    const client = makeClient()
+    const clients = fakeClients([client])
+
+    await expect(
+      resubscribeOnChange(pushManager, { oldSubscription: { options: { userVisibleOnly: true }, toJSON: () => ({}) } }, clients)
+    ).resolves.toBeUndefined()
+    expect(client.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('non fa nulla se non ci sono opzioni né fallback disponibili', async () => {
+    const pushManager = { subscribe: vi.fn() }
+    const client = makeClient()
+    const clients = fakeClients([client])
+
+    await resubscribeOnChange(pushManager, {}, clients)
+
+    expect(pushManager.subscribe).not.toHaveBeenCalled()
+    expect(client.postMessage).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/pushResubscribe.ts
+++ b/src/lib/pushResubscribe.ts
@@ -1,0 +1,61 @@
+/**
+ * Re-subscribe logic for the service worker `pushsubscriptionchange` event,
+ * following the MDN canonical pattern: when the browser refreshes or revokes a
+ * push subscription, re-subscribe from within the SW and notify open clients so
+ * the server record gets updated — without depending on a window being open.
+ *
+ * Limitation: iOS Safari NEVER fires `pushsubscriptionchange`
+ * (BCD `api.ServiceWorkerGlobalScope.pushsubscriptionchange_event`:
+ * `safari_ios=false`, verified 2026-06-26), so this path only helps
+ * Chrome/Firefox/desktop Safari. On iOS the subscription is recovered by the
+ * in-app re-enable nudge (NotificationPrompt 'lost' state), not here.
+ */
+
+interface PushSubscriptionLike {
+  options?: PushSubscriptionOptionsInit
+  toJSON: () => unknown
+}
+
+interface SubscriptionChangeLike {
+  oldSubscription?: PushSubscriptionLike | null
+  newSubscription?: PushSubscriptionLike | null
+}
+
+interface PushManagerLike {
+  subscribe: (options: PushSubscriptionOptionsInit) => Promise<PushSubscriptionLike>
+}
+
+interface ClientsLike {
+  matchAll: (options: { type: 'window' }) => Promise<ReadonlyArray<{ postMessage: (message: unknown) => void }>>
+}
+
+export async function resubscribeOnChange(
+  pushManager: PushManagerLike,
+  event: SubscriptionChangeLike,
+  clients: ClientsLike,
+  fallbackApplicationServerKey?: PushSubscriptionOptionsInit['applicationServerKey'],
+): Promise<void> {
+  let subscription = event.newSubscription ?? null
+
+  if (!subscription) {
+    // Firefox doesn't populate oldSubscription, so fall back to the VAPID key.
+    const options = event.oldSubscription?.options
+      ?? (fallbackApplicationServerKey
+        ? { userVisibleOnly: true, applicationServerKey: fallbackApplicationServerKey }
+        : null)
+    if (!options) return
+
+    try {
+      subscription = await pushManager.subscribe(options)
+    } catch {
+      // Degrade silently: the in-app syncSubscription() retries on next app open.
+      return
+    }
+  }
+
+  const subscriptionJson = subscription.toJSON()
+  const windowClients = await clients.matchAll({ type: 'window' })
+  for (const client of windowClients) {
+    client.postMessage({ type: 'PUSH_SUBSCRIPTION_CHANGED', subscription: subscriptionJson })
+  }
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -4,6 +4,7 @@ import { NavigationRoute, registerRoute } from 'workbox-routing'
 import { CacheFirst } from 'workbox-strategies'
 import { ExpirationPlugin } from 'workbox-expiration'
 import { CacheableResponsePlugin } from 'workbox-cacheable-response'
+import { resubscribeOnChange } from './lib/pushResubscribe'
 
 declare let self: ServiceWorkerGlobalScope
 
@@ -115,20 +116,21 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
   )
 })
 
+// Quando il browser rinnova/revoca la subscription, ri-sottoscrive nel SW e
+// notifica i client (pattern canonico MDN), senza dipendere da una finestra
+// aperta. NB: iOS Safari NON emette mai questo evento (BCD safari_ios=false,
+// verificato 2026-06-26) → su iPhone il recupero avviene dal nudge in-app.
 self.addEventListener('pushsubscriptionchange', (event: Event) => {
   const pushEvent = event as ExtendableEvent & {
     oldSubscription?: PushSubscription
     newSubscription?: PushSubscription
   }
-
-  if (!pushEvent.newSubscription) return
-
-  const subscriptionJson = pushEvent.newSubscription.toJSON()
   pushEvent.waitUntil(
-    self.clients.matchAll({ type: 'window' }).then((windowClients) => {
-      for (const client of windowClients) {
-        client.postMessage({ type: 'PUSH_SUBSCRIPTION_CHANGED', subscription: subscriptionJson })
-      }
-    })
+    resubscribeOnChange(
+      self.registration.pushManager,
+      pushEvent,
+      self.clients,
+      import.meta.env.VITE_VAPID_PUBLIC_KEY,
+    )
   )
 })


### PR DESCRIPTION
## Contesto

Un alimento in scadenza tra 3 giorni non ha generato notifica sull'iPhone, pur con PWA installata. Il debug sistematico ha mostrato che cron → edge function → query → invio funzionavano: l'unica subscription registrata era un **vecchio device Android**. iOS aveva **invalidato silenziosamente** la subscription dell'iPhone, senza che l'app se ne accorgesse.

### Causa radice (verificata su MDN)
- **`pushsubscriptionchange` non esiste su iOS Safari** — BCD `api.ServiceWorkerGlobalScope.pushsubscriptionchange_event`: `safari_ios=false` (verificato 2026-06-26). L'evento che dovrebbe ri-registrare la subscription non viene mai emesso.
- **`pushManager.subscribe()` va invocato su user gesture** — MDN: i browser stanno vietando le subscribe fuori da una gesture (Firefox già da v72). Quindi **niente re-subscribe silenzioso**.

Conseguenza: `Notification.permission` resta `granted` anche a subscription persa, quindi l'app *sembrava* a posto e il banner home (nascosto quando `permission !== 'default'`) non avvisava mai.

## Modifiche

- **`usePushSubscription`** — nuovo status **`'lost'`** (permesso `granted` ma nessuna subscription attiva), distinto dall'upsell `'prompt'`.
- **`NotificationPrompt`** — nudge **"Riattiva"** in home per lo stato `'lost'`: sempre visibile (anche con 0 alimenti), dismiss **solo per-sessione** (un malfunzionamento non va zittito per sempre). Banner ora guidato dallo status del hook; estratto `PromptBanner` per togliere duplicazione.
- **`NotificationSettings`** — lo stato `'lost'` mostra toggle "Attiva" + avviso warning.
- **`src/lib/pushResubscribe.ts` (nuovo) + `sw.ts`** — `pushsubscriptionchange` ri-sottoscrive nel SW (pattern canonico MDN, fallback chiave VAPID) come **miglioria non-iOS** (Chrome/Firefox/desktop Safari).

Il re-subscribe avviene sempre **su gesture** (best practice MDN) e funziona su iOS.

## Limiti dichiarati
- L'handler SW **non aiuta iPhone** (evento assente su iOS): su iOS il recupero passa dal nudge in-app. Documentato nei commenti.

## Test
- **195 verdi** (36 file). Nuovi: hook (`'lost'` vs `'subscribed'`+sync), banner (`'lost'` sempre visibile, dismiss per-sessione, safeguard anti-silenziamento), settings, helper SW (re-subscribe, fallback Firefox, degrado senza throw).
- `tsc -b` ✅ · eslint ✅ · `npm run build` ✅ (il SW si bundle-a col nuovo import).

## Verifica post-deploy
Il banner `'lost'` è osservabile solo in produzione: alla prossima invalidazione iOS deve comparire "Le notifiche si sono disattivate. Riattivale".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
