### PR TITLE
Consolida fondamenta progetto

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Segnala un problema riproducibile in Entro.
+title: "fix: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Grazie per la segnalazione. Scrivi in italiano o inglese. Per vulnerabilita' di sicurezza usa `SECURITY.md`, non una issue pubblica.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Descrizione
+      description: Cosa succede?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Passi per riprodurre
+      placeholder: |
+        1. Vai a ...
+        2. Tocca ...
+        3. Osserva ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamento atteso
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Ambiente
+      placeholder: "Browser, OS, device, installata come PWA si/no"
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Note aggiuntive
+      description: Screenshot, log o contesto utile.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Proponi una funzionalita' o un miglioramento.
+title: "feat: "
+labels: []
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema o opportunita'
+      description: Quale bisogno utente risolve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposta
+      description: Descrivi il comportamento desiderato.
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Approccio tecnico suggerito
+      description: File, API, dati o pattern rilevanti.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criteri di accettazione
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Note
+      description: Vincoli, rischi o riferimenti.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Cosa cambia
+
+-
+
+## Verifiche
+
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm test`
+- [ ] `npm run build`
+
+## Database e sicurezza
+
+- [ ] Nessuna modifica database
+- [ ] Migration additive con RLS e GRANT espliciti
+- [ ] Autorizzazione e azioni distruttive coperte da test o smoke test
+
+## UI/mobile
+
+- [ ] Nessuna modifica UI
+- [ ] Verificata in viewport mobile
+- [ ] Testi e documentazione aggiornati se cambia il comportamento utente

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint, typecheck and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      VITE_SUPABASE_URL: http://127.0.0.1:54321
+      VITE_SUPABASE_ANON_KEY: test-anon-key
+      VITE_APP_URL: http://localhost:5173
+      VITE_APP_NAME: entro
+      VITE_ENABLE_BARCODE_SCANNER: "true"
+      VITE_ENABLE_SWIPE_GESTURES: "true"
+      VITE_ENABLE_SHARED_LISTS: "true"
+      VITE_ENABLE_NOTIFICATIONS: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test:ci
+
+      - name: Build
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Added
+- Baseline Supabase ricostruttiva in `supabase/migrations/` per rendere `supabase db reset` riproducibile da clone pulito.
+- CI GitHub Actions con lint, typecheck, test e build su push/PR.
+- Documenti contributor/community: `CONTRIBUTING.md`, `SECURITY.md`, template issue e template PR.
+- Tipi Supabase generati in `src/lib/supabase.types.ts` con comando `npm run supabase:types`.
+
+### Changed
+- Il client Supabase ora usa i tipi generati come fonte unica invece dei tipi manuali incorporati in `src/lib/supabase.ts`.
+- La documentazione pubblica di deploy privilegia Supabase locale come ambiente di verifica, con staging remoto opzionale.
+- `netlify.toml` non contiene piu' URL/key Supabase pubblicabili: quei valori passano dalle environment variables Netlify.
+
+### Fixed
+- Aggiunti GRANT espliciti alle tabelle/funzione push notification nella migration dedicata, coerenti con il Data API hardening.
+- La migration cron notification ora e' difensiva quando `pg_cron` non e' disponibile in locale.
+
 ## [1.9.0] - 2026-07-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contribuire a Entro
+
+Entro e' una PWA italiana per gestire scadenze alimentari, liste condivise e notifiche. Il progetto e' pubblico, ma alcune note operative restano in documenti locali privati: le issue GitHub e questa guida devono essere sufficienti per contribuire.
+
+## English summary
+
+Entro is an Italian food-expiry tracking PWA built with React, Vite, TypeScript, Tailwind and Supabase. Please run lint, typecheck and tests before opening a pull request. Database changes must include RLS and explicit grants.
+
+## Prerequisiti
+
+- Node.js 20
+- npm
+- Docker, richiesto per Supabase locale
+- Supabase CLI
+- Un progetto Supabase solo se devi testare flussi remoti; per default usa Supabase locale
+
+## Setup locale
+
+```bash
+git clone https://github.com/E-Lop/entro.git
+cd entro
+npm ci
+cp .env.example .env.local
+```
+
+Compila `.env.local` con i valori del tuo progetto Supabase locale o remoto:
+
+```bash
+VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_ANON_KEY=<local-anon-key>
+VITE_APP_URL=http://localhost:5173
+VITE_APP_NAME=entro
+VITE_ENABLE_BARCODE_SCANNER=true
+VITE_ENABLE_SWIPE_GESTURES=true
+VITE_ENABLE_SHARED_LISTS=true
+VITE_ENABLE_NOTIFICATIONS=true
+```
+
+## Supabase locale
+
+Avvia Supabase locale con Docker:
+
+```bash
+supabase start
+supabase db reset
+npm run supabase:types
+```
+
+La catena canonica delle migration vive in `supabase/migrations/`. I tipi TypeScript generati vivono in `src/lib/supabase.types.ts` e vengono riesportati dal client in `src/lib/supabase.ts`. La cartella storica `migrations/` resta solo come archivio finche' non viene consolidata.
+
+## Comandi di verifica
+
+```bash
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+La CI GitHub esegue gli stessi controlli su push e pull request.
+
+## Regole database
+
+Ogni nuova tabella o funzione nello schema `public` deve includere:
+
+- RLS abilitata;
+- policy coerenti con il modello dati;
+- `GRANT` espliciti per i ruoli necessari;
+- test o smoke test che coprano autorizzazione e business rule.
+
+Template minimo per una tabella privata utente:
+
+```sql
+ALTER TABLE public.my_table ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own rows"
+  ON public.my_table FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.my_table TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.my_table TO service_role;
+```
+
+## Pull request
+
+Prima di aprire una PR:
+
+- mantieni lo scope stretto;
+- aggiorna documentazione e `CHANGELOG.md` se cambia comportamento utente;
+- aggiungi test per validation, authorization, business rules e azioni distruttive;
+- verifica le modifiche UI in viewport mobile.
+
+Usa Conventional Commits per i messaggi principali, per esempio `feat:`, `fix:`, `docs:`, `test:`, `chore:`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # entro
 
+[![CI](https://github.com/E-Lop/entro/actions/workflows/ci.yml/badge.svg)](https://github.com/E-Lop/entro/actions/workflows/ci.yml)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/8439a7e9-1a8a-4401-83f1-37f349082a9b/deploy-status)](https://app.netlify.com/projects/entro-il/deploys)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev/)
@@ -12,6 +13,12 @@
 Una Progressive Web App completa per il tracciamento delle scadenze alimentari, con scansione barcode, liste condivise in tempo reale e conformità GDPR. Pensata per famiglie e coinquilini che vogliono sprecare meno cibo.
 
 **[Prova l'app live &rarr;](https://entroapp.it)**
+
+## What is this?
+
+Entro is an open-source Italian PWA for tracking food expiry dates, reducing waste and sharing a household food list in real time. It is built as a production app and as a public portfolio project.
+
+**[Open the live app &rarr;](https://entroapp.it)**
 
 ---
 
@@ -58,7 +65,7 @@ Il progetto copre l'intero ciclo di vita di un'applicazione web: dal design del 
 | Categoria | Tecnologia |
 |---|---|
 | **Frontend** | React 19, TypeScript 5.6 |
-| **Build Tool** | Vite 6 (SWC) |
+| **Build Tool** | Vite 8 (SWC) |
 | **Styling** | Tailwind CSS 3, shadcn/ui |
 | **State Management** | Zustand (client), TanStack Query (server) |
 | **Offline** | IndexedDB (idb-keyval), PersistQueryClient, mutation queue |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## English summary
+
+Please report security issues privately. Do not open public issues for vulnerabilities, secrets, data exposure, authentication bypasses or RLS problems.
+
+## Segnalare una vulnerabilita'
+
+Per segnalazioni di sicurezza, scrivi privatamente a:
+
+**support@entroapp.it**
+
+Includi, se possibile:
+
+- descrizione del problema;
+- passi per riprodurlo;
+- impatto stimato;
+- URL, screenshot o log rilevanti;
+- eventuale mitigazione suggerita.
+
+Non pubblicare dettagli sensibili in issue GitHub, pull request o discussioni pubbliche.
+
+## Ambito
+
+Sono considerate segnalazioni di sicurezza:
+
+- accesso non autorizzato a dati alimenti, liste, inviti o account;
+- bypass di autenticazione o autorizzazione;
+- policy RLS mancanti o errate;
+- segreti esposti;
+- problemi nelle Edge Functions Supabase;
+- vulnerabilita' XSS, CSRF o supply chain;
+- perdita o cancellazione non autorizzata di dati.
+
+## Note per contributor
+
+Le modifiche database devono sempre includere RLS e GRANT espliciti dove richiesto. Le funzioni con privilegi elevati devono essere minime, testate e documentate.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # Documentation
 
-This directory contains all project documentation, organized into three main sections:
+This directory contains public project documentation.
 
-## 📁 Structure
+## Structure
 
 ### `/guides/`
 User-facing documentation and guides:
@@ -10,28 +10,11 @@ User-facing documentation and guides:
 - **privacy.md** - Privacy policy and data handling
 - **PHASE_6_LAUNCH_CHECKLIST.md** - Launch preparation checklist
 
-### `/development/`
-Technical documentation for developers and contributors:
-- Implementation plans and architecture decisions
-- Bug analysis and fixes
-- Testing checklists and procedures
-- Feature specifications
-- Integration guides
-
-### `/private/` 🔒
-Internal documentation (not included in repository):
-- Project overview and roadmap
-- Database schemas
-- Internal technical specifications
-- Development notes
-
-> **Note:** The `/private/` directory is excluded from version control via `.gitignore` and contains sensitive internal documentation.
-
 ## Contributing
 
 When adding new documentation:
 - **User guides** → `/guides/`
-- **Technical/implementation docs** → `/development/`
-- **Internal/sensitive docs** → `/private/`
+- **Contributor setup** → root-level docs such as `CONTRIBUTING.md`
+- **Internal/sensitive docs** → keep them out of the public repository
 
 Keep documentation up-to-date as features and implementations evolve.

--- a/docs/guides/DEPLOY.md
+++ b/docs/guides/DEPLOY.md
@@ -7,6 +7,27 @@ Guida passo-passo per deployare **entro** su Netlify.
 - Account Netlify (gratuito): https://app.netlify.com/signup
 - Progetto Supabase attivo con database configurato
 - Repository GitHub (opzionale ma consigliato)
+- Per sviluppo e verifica migration: Docker + Supabase CLI in locale
+
+## 🧪 Supabase locale per sviluppo
+
+Per validare migration e flussi database senza toccare la produzione:
+
+```bash
+supabase start
+supabase db reset
+npm run supabase:types
+```
+
+Poi configura `.env.local` con i valori locali stampati dalla CLI:
+
+```bash
+VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_ANON_KEY=<local-anon-key>
+VITE_APP_URL=http://localhost:5173
+```
+
+Lo staging remoto Supabase è opzionale: sul piano Free può consumare uno dei progetti attivi disponibili. Per default usare Supabase locale.
 
 ## 🔧 Step 1: Preparazione Environment Variables
 
@@ -43,7 +64,7 @@ git push origin main
    VITE_ENABLE_BARCODE_SCANNER=true
    VITE_ENABLE_SWIPE_GESTURES=true
    VITE_ENABLE_NOTIFICATIONS=true
-   VITE_ENABLE_SHARED_LISTS=false
+   VITE_ENABLE_SHARED_LISTS=true
    ```
 7. Click **"Deploy site"**
 
@@ -77,6 +98,9 @@ Se non l'hai fatto durante il deploy:
 1. Vai su **Site settings** → **Environment variables**
 2. Click **"Add a variable"**
 3. Aggiungi tutte le variabili necessarie (vedi Step 1)
+
+`VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY` devono vivere nelle environment variables Netlify, non in `netlify.toml`.
+Le impostazioni non sensibili possono restare in `netlify.toml`: la documentazione Netlify conferma che il file puo' dichiarare environment variables di build e che, in caso di conflitto, la configurazione nel file sovrascrive la UI. Per valori sensibili o ruotabili, usare UI/CLI/API Netlify.
 
 **IMPORTANTE**: Dopo aver aggiunto le env vars, fai un **re-deploy**:
 - Vai su **Deploys** → **Trigger deploy** → **Clear cache and deploy site**

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,11 @@
+# Migration storiche
+
+Questa cartella contiene migration storiche scritte prima del consolidamento della catena Supabase canonica.
+
+La fonte operativa per `supabase db reset`, CI e nuovi setup deve essere:
+
+```text
+supabase/migrations/
+```
+
+Non aggiungere nuove migration in questa cartella. Se serve recuperare contesto storico, leggere questi file e poi portare la modifica nella catena canonica in `supabase/migrations/`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,14 +10,12 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  VITE_SUPABASE_URL = "https://rmbmmwcxtnanacxbkihc.supabase.co"
-  VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJtYm1td2N4dG5hbmFjeGJraWhjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njc5MzA0NDMsImV4cCI6MjA4MzUwNjQ0M30.tl3mozcbXBQPx1JAZYm4V4JqfxPoq1Qv-35_UgiJ3Ac"
   VITE_APP_URL = "https://entroapp.it"
   VITE_APP_NAME = "entro"
   VITE_ENABLE_BARCODE_SCANNER = "true"
   VITE_ENABLE_SWIPE_GESTURES = "true"
   VITE_ENABLE_SHARED_LISTS = "true"
-  # VITE_ENABLE_NOTIFICATIONS = "false"  # Not implemented yet
+  VITE_ENABLE_NOTIFICATIONS = "true"
 
 [[headers]]
   for = "/*"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc -b",
+    "supabase:types": "supabase gen types typescript --local > src/lib/supabase.types.ts",
     "detect:design": "node scripts/detect-design.mjs",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:ci": "vitest run --no-file-parallelism --maxWorkers=1",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -129,9 +129,9 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
         name: initialData.name,
         category_id: initialData.category_id,
         expiry_date: format(new Date(initialData.expiry_date), 'yyyy-MM-dd'),
-        storage_location: initialData.storage_location,
+        storage_location: initialData.storage_location as FoodFormData['storage_location'],
         quantity: initialData.quantity,
-        quantity_unit: initialData.quantity_unit,
+        quantity_unit: initialData.quantity_unit as FoodFormData['quantity_unit'],
         notes: initialData.notes,
         image_url: initialData.image_url,
       })

--- a/src/lib/dataExport.ts
+++ b/src/lib/dataExport.ts
@@ -100,7 +100,7 @@ export async function exportUserData(): Promise<{ success: boolean; error: Error
         const { members } = await getListMembers(list.id)
         listData.members = members.map((m) => ({
           userId: m.user_id,
-          joinedAt: m.joined_at,
+          joinedAt: m.joined_at ?? 'N/A',
         }))
       }
     } catch (listError) {

--- a/src/lib/foodFilters.ts
+++ b/src/lib/foodFilters.ts
@@ -22,7 +22,7 @@ export function filterFoods(foods: Food[], filters: FilterParams, now: Date = ne
 }
 
 /** Ordina (copia) lato client: collazione italiana per `name`, ordinamento
- *  lessicografico per date/id ISO. Tutti i campi ordinabili sono `string`. */
+ *  lessicografico per date/id ISO. */
 export function sortFoods(
   foods: Food[],
   sortBy: FilterParams['sortBy'] = 'expiry_date',
@@ -30,8 +30,8 @@ export function sortFoods(
 ): Food[] {
   const dir = sortOrder === 'desc' ? -1 : 1
   return [...foods].sort((a, b) => {
-    const av = a[sortBy]
-    const bv = b[sortBy]
+    const av = a[sortBy] ?? ''
+    const bv = b[sortBy] ?? ''
     const cmp = sortBy === 'name'
       ? av.localeCompare(bv, 'it', { sensitivity: 'base' })
       : av < bv ? -1 : av > bv ? 1 : 0

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
+import type { Database } from './supabase.types'
 
-// Supabase client configuration
+export type { Database } from './supabase.types'
+
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
@@ -11,151 +13,22 @@ if (!supabaseUrl || !supabaseAnonKey) {
 }
 
 /**
- * Create Supabase client with auth configuration
+ * Create Supabase client with auth configuration.
  *
- * SECURITY NOTE - detectSessionInUrl: true
- * This setting allows Supabase to automatically extract authentication tokens from URLs.
- * It is REQUIRED for:
- * - Password reset flows (user clicks email link with #access_token=...)
- * - Magic link authentication (passwordless login)
- * - OAuth provider redirects
- *
- * IMPORTANT: This means users can be automatically logged in if they:
- * - Click a password reset link (even in incognito mode)
- * - Access a URL with an active auth token in the fragment
- * - Are redirected from an OAuth provider
- *
- * This is NORMAL and EXPECTED behavior. If you see unexpected auto-login:
- * 1. Check if there's a #access_token= in the URL
- * 2. Check browser DevTools → Application → Local Storage for auth tokens
- * 3. Verify the auth event type in authStore logging
- *
- * DO NOT disable this unless you want to break password reset functionality.
+ * `detectSessionInUrl: true` is required for password reset, magic link and
+ * OAuth redirects because Supabase reads auth tokens from URL fragments.
  */
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {
     autoRefreshToken: true,
     persistSession: true,
-    detectSessionInUrl: true, // Required for password reset and magic links
+    detectSessionInUrl: true,
   },
   realtime: {
     params: {
       eventsPerSecond: 10,
     },
-    heartbeatIntervalMs: 15000, // 15s instead of default 25s for better mobile detection
-    timeout: 20000, // Connection timeout
+    heartbeatIntervalMs: 15000,
+    timeout: 20000,
   },
 })
-
-// Database types (updated for shared lists feature)
-export type Database = {
-  public: {
-    Tables: {
-      foods: {
-        Row: {
-          id: string
-          user_id: string
-          list_id: string | null // Added for shared lists
-          name: string
-          quantity: number | null
-          quantity_unit: 'pz' | 'kg' | 'g' | 'l' | 'ml' | 'confezioni' | null
-          expiry_date: string
-          category_id: string
-          storage_location: 'fridge' | 'freezer' | 'pantry'
-          image_url: string | null
-          barcode: string | null
-          notes: string | null
-          status: 'active' | 'consumed' | 'expired' | 'wasted'
-          consumed_at: string | null
-          created_at: string
-          updated_at: string
-          deleted_at: string | null
-        }
-        Insert: Omit<Database['public']['Tables']['foods']['Row'], 'id' | 'created_at' | 'updated_at'>
-        Update: Partial<Database['public']['Tables']['foods']['Insert']>
-      }
-      categories: {
-        Row: {
-          id: string
-          name: string
-          name_it: string
-          icon: string
-          color: string
-          default_storage: 'fridge' | 'freezer' | 'pantry'
-          average_shelf_life_days: number
-          created_at: string
-        }
-      }
-      lists: {
-        Row: {
-          id: string
-          name: string
-          created_by: string
-          created_at: string
-          updated_at: string
-        }
-        Insert: Omit<Database['public']['Tables']['lists']['Row'], 'id' | 'created_at' | 'updated_at'>
-        Update: Partial<Database['public']['Tables']['lists']['Insert']>
-      }
-      list_members: {
-        Row: {
-          id: string
-          list_id: string
-          user_id: string
-          joined_at: string
-        }
-        Insert: Omit<Database['public']['Tables']['list_members']['Row'], 'id' | 'joined_at'>
-        Update: Partial<Database['public']['Tables']['list_members']['Insert']>
-      }
-      invites: {
-        Row: {
-          id: string
-          list_id: string
-          email: string
-          token: string
-          created_by: string
-          status: 'pending' | 'accepted' | 'expired'
-          created_at: string
-          expires_at: string
-          accepted_at: string | null
-        }
-        Insert: Omit<Database['public']['Tables']['invites']['Row'], 'id' | 'created_at'>
-        Update: Partial<Database['public']['Tables']['invites']['Insert']>
-      }
-      push_subscriptions: {
-        Row: {
-          id: string
-          user_id: string
-          endpoint: string
-          p256dh: string
-          auth_key: string
-          user_agent: string | null
-          created_at: string
-          updated_at: string
-        }
-        Insert: Omit<Database['public']['Tables']['push_subscriptions']['Row'], 'id' | 'created_at' | 'updated_at'>
-        Update: Partial<Database['public']['Tables']['push_subscriptions']['Insert']>
-      }
-      notification_preferences: {
-        Row: {
-          id: string
-          user_id: string
-          enabled: boolean
-          expiry_intervals: number[]
-          quiet_hours_enabled: boolean
-          quiet_hours_start: number
-          quiet_hours_end: number
-          max_notifications_per_day: number
-          timezone: string
-          last_notification_sent_at: string | null
-          notifications_sent_today: number
-          notifications_sent_date: string | null
-          created_at: string
-          updated_at: string
-        }
-        Insert: Omit<Database['public']['Tables']['notification_preferences']['Row'], 'id' | 'created_at' | 'updated_at'>
-        Update: Partial<Database['public']['Tables']['notification_preferences']['Insert']>
-      }
-    }
-  }
-}

--- a/src/lib/supabase.types.ts
+++ b/src/lib/supabase.types.ts
@@ -1,0 +1,505 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      categories: {
+        Row: {
+          average_shelf_life_days: number
+          color: string
+          created_at: string | null
+          default_storage: string
+          icon: string
+          id: string
+          name: string
+          name_it: string
+        }
+        Insert: {
+          average_shelf_life_days?: number
+          color: string
+          created_at?: string | null
+          default_storage: string
+          icon: string
+          id?: string
+          name: string
+          name_it: string
+        }
+        Update: {
+          average_shelf_life_days?: number
+          color?: string
+          created_at?: string | null
+          default_storage?: string
+          icon?: string
+          id?: string
+          name?: string
+          name_it?: string
+        }
+        Relationships: []
+      }
+      foods: {
+        Row: {
+          barcode: string | null
+          category_id: string
+          consumed_at: string | null
+          created_at: string | null
+          deleted_at: string | null
+          expiry_date: string
+          id: string
+          image_url: string | null
+          list_id: string | null
+          name: string
+          notes: string | null
+          quantity: number | null
+          quantity_unit: string | null
+          status: string | null
+          storage_location: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          barcode?: string | null
+          category_id: string
+          consumed_at?: string | null
+          created_at?: string | null
+          deleted_at?: string | null
+          expiry_date: string
+          id?: string
+          image_url?: string | null
+          list_id?: string | null
+          name: string
+          notes?: string | null
+          quantity?: number | null
+          quantity_unit?: string | null
+          status?: string | null
+          storage_location: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          barcode?: string | null
+          category_id?: string
+          consumed_at?: string | null
+          created_at?: string | null
+          deleted_at?: string | null
+          expiry_date?: string
+          id?: string
+          image_url?: string | null
+          list_id?: string | null
+          name?: string
+          notes?: string | null
+          quantity?: number | null
+          quantity_unit?: string | null
+          status?: string | null
+          storage_location?: string
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "foods_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "foods_list_id_fkey"
+            columns: ["list_id"]
+            isOneToOne: false
+            referencedRelation: "lists"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      invites: {
+        Row: {
+          accepted_at: string | null
+          created_at: string | null
+          created_by: string
+          email: string | null
+          expires_at: string
+          id: string
+          list_id: string
+          pending_user_email: string | null
+          short_code: string | null
+          status: string
+          token: string
+        }
+        Insert: {
+          accepted_at?: string | null
+          created_at?: string | null
+          created_by: string
+          email?: string | null
+          expires_at: string
+          id?: string
+          list_id: string
+          pending_user_email?: string | null
+          short_code?: string | null
+          status?: string
+          token: string
+        }
+        Update: {
+          accepted_at?: string | null
+          created_at?: string | null
+          created_by?: string
+          email?: string | null
+          expires_at?: string
+          id?: string
+          list_id?: string
+          pending_user_email?: string | null
+          short_code?: string | null
+          status?: string
+          token?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "invites_list_id_fkey"
+            columns: ["list_id"]
+            isOneToOne: false
+            referencedRelation: "lists"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      list_members: {
+        Row: {
+          id: string
+          joined_at: string | null
+          list_id: string
+          user_id: string
+        }
+        Insert: {
+          id?: string
+          joined_at?: string | null
+          list_id: string
+          user_id: string
+        }
+        Update: {
+          id?: string
+          joined_at?: string | null
+          list_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "list_members_list_id_fkey"
+            columns: ["list_id"]
+            isOneToOne: false
+            referencedRelation: "lists"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      lists: {
+        Row: {
+          created_at: string | null
+          created_by: string
+          id: string
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          created_by: string
+          id?: string
+          name?: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          created_by?: string
+          id?: string
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      notification_preferences: {
+        Row: {
+          created_at: string
+          enabled: boolean
+          expiry_intervals: number[]
+          id: string
+          last_notification_sent_at: string | null
+          max_notifications_per_day: number
+          notifications_sent_date: string | null
+          notifications_sent_today: number
+          quiet_hours_enabled: boolean
+          quiet_hours_end: number
+          quiet_hours_start: number
+          timezone: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          enabled?: boolean
+          expiry_intervals?: number[]
+          id?: string
+          last_notification_sent_at?: string | null
+          max_notifications_per_day?: number
+          notifications_sent_date?: string | null
+          notifications_sent_today?: number
+          quiet_hours_enabled?: boolean
+          quiet_hours_end?: number
+          quiet_hours_start?: number
+          timezone?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          enabled?: boolean
+          expiry_intervals?: number[]
+          id?: string
+          last_notification_sent_at?: string | null
+          max_notifications_per_day?: number
+          notifications_sent_date?: string | null
+          notifications_sent_today?: number
+          quiet_hours_enabled?: boolean
+          quiet_hours_end?: number
+          quiet_hours_start?: number
+          timezone?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      push_subscriptions: {
+        Row: {
+          auth_key: string
+          created_at: string
+          endpoint: string
+          id: string
+          p256dh: string
+          updated_at: string
+          user_agent: string | null
+          user_id: string
+        }
+        Insert: {
+          auth_key: string
+          created_at?: string
+          endpoint: string
+          id?: string
+          p256dh: string
+          updated_at?: string
+          user_agent?: string | null
+          user_id: string
+        }
+        Update: {
+          auth_key?: string
+          created_at?: string
+          endpoint?: string
+          id?: string
+          p256dh?: string
+          updated_at?: string
+          user_agent?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      create_personal_list: {
+        Args: never
+        Returns: {
+          error_message: string
+          list_id: string
+          success: boolean
+        }[]
+      }
+      delete_user: { Args: never; Returns: undefined }
+      get_expiring_foods_for_notifications: {
+        Args: never
+        Returns: {
+          category_name: string
+          days_until_expiry: number
+          expiry_date: string
+          food_id: string
+          food_name: string
+          timezone: string
+          user_id: string
+        }[]
+      }
+      get_shared_list_member_ids: {
+        Args: never
+        Returns: {
+          user_id: string
+        }[]
+      }
+      get_user_list_ids: {
+        Args: never
+        Returns: {
+          list_id: string
+        }[]
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const
+

--- a/supabase/migrations/20260109_baseline_core_schema.sql
+++ b/supabase/migrations/20260109_baseline_core_schema.sql
@@ -1,0 +1,472 @@
+-- Baseline ricostruttiva dello schema core Entro prima delle migration push.
+--
+-- Origine: lettura sola produzione Supabase project rmbmmwcxtnanacxbkihc
+-- aggiornata il 2026-07-03.
+--
+-- ATTENZIONE:
+-- - Non applicare questa migration in produzione: gli oggetti esistono gia'.
+-- - Serve per rendere `supabase db reset` riproducibile da clone pulito.
+-- - Prima di qualunque `supabase db push`, marcare questa baseline come applied
+--   nella history remota con `supabase migration repair`.
+
+create extension if not exists "pgcrypto" with schema extensions;
+create extension if not exists "uuid-ossp" with schema extensions;
+
+create table public.categories (
+  id uuid default gen_random_uuid() primary key,
+  name text not null unique,
+  name_it text not null,
+  icon text not null,
+  color text not null,
+  default_storage text not null check (default_storage = any (array['fridge'::text, 'freezer'::text, 'pantry'::text])),
+  average_shelf_life_days integer not null default 7,
+  created_at timestamptz default now()
+);
+
+insert into public.categories (name, name_it, icon, color, default_storage, average_shelf_life_days) values
+  ('bakery', 'Pane e Pasta', 'wheat', '#D97706', 'pantry', 3),
+  ('beverages', 'Bevande', 'cup-soda', '#8B5CF6', 'pantry', 180),
+  ('condiments', 'Condimenti', 'soup', '#F97316', 'pantry', 365),
+  ('dairy', 'Latticini', 'milk', '#3B82F6', 'fridge', 7),
+  ('fish', 'Pesce', 'fish', '#06B6D4', 'fridge', 2),
+  ('frozen', 'Surgelati', 'snowflake', '#0EA5E9', 'freezer', 90),
+  ('fruits', 'Frutta', 'apple', '#F59E0B', 'fridge', 5),
+  ('meat', 'Carne', 'beef', '#EF4444', 'fridge', 3),
+  ('other', 'Altro', 'package', '#6B7280', 'pantry', 7),
+  ('snacks', 'Snack', 'candy', '#EC4899', 'pantry', 30),
+  ('vegetables', 'Verdura', 'carrot', '#10B981', 'fridge', 7)
+on conflict (name) do update set
+  name_it = excluded.name_it,
+  icon = excluded.icon,
+  color = excluded.color,
+  default_storage = excluded.default_storage,
+  average_shelf_life_days = excluded.average_shelf_life_days;
+
+create table public.lists (
+  id uuid default gen_random_uuid() primary key,
+  name text not null default 'La mia lista',
+  created_by uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+comment on table public.lists is 'Shared lists that can be accessed by multiple users';
+comment on column public.lists.name is 'Display name for the list';
+comment on column public.lists.created_by is 'User who created the list';
+
+create index idx_lists_created_by on public.lists(created_by);
+
+create table public.list_members (
+  id uuid default gen_random_uuid() primary key,
+  list_id uuid not null references public.lists(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  joined_at timestamptz default now(),
+  unique (list_id, user_id)
+);
+
+comment on table public.list_members is 'Junction table tracking which users belong to which lists';
+comment on column public.list_members.joined_at is 'When the user joined this list';
+
+create index idx_list_members_list_id on public.list_members(list_id);
+create index idx_list_members_user_id on public.list_members(user_id);
+
+create table public.invites (
+  id uuid default gen_random_uuid() primary key,
+  list_id uuid not null references public.lists(id) on delete cascade,
+  email text,
+  token text not null unique,
+  created_by uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'pending' check (status = any (array['pending'::text, 'accepted'::text, 'expired'::text])),
+  created_at timestamptz default now(),
+  expires_at timestamptz not null,
+  accepted_at timestamptz,
+  short_code varchar(8),
+  pending_user_email varchar(255),
+  constraint valid_expiry check (expires_at > created_at)
+);
+
+comment on table public.invites is 'Invite tokens for sharing lists with new users';
+comment on column public.invites.email is 'Email is now optional - invites can be anonymous and shared with anyone';
+comment on column public.invites.token is 'Unique invite token (32 characters, nanoid)';
+comment on column public.invites.status is 'pending = not yet accepted, accepted = user joined, expired = past expiry date';
+comment on column public.invites.expires_at is 'Token expires after 7 days by default';
+comment on column public.invites.short_code is 'Short 6-character alphanumeric code for easy sharing (e.g., ABC123)';
+comment on column public.invites.pending_user_email is 'Email of user who signed up with this invite but has not yet confirmed email';
+
+create index idx_invites_token on public.invites(token);
+create index idx_invites_email on public.invites(email) where status = 'pending';
+create index idx_invites_list_id on public.invites(list_id);
+create unique index idx_invites_short_code on public.invites(short_code);
+create index idx_invites_pending_user_email on public.invites(pending_user_email) where pending_user_email is not null;
+
+create table public.foods (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  quantity numeric(10, 2),
+  quantity_unit text check (quantity_unit = any (array['pz'::text, 'kg'::text, 'g'::text, 'l'::text, 'ml'::text, 'confezioni'::text])),
+  expiry_date date not null,
+  category_id uuid not null references public.categories(id),
+  storage_location text not null check (storage_location = any (array['fridge'::text, 'freezer'::text, 'pantry'::text])),
+  image_url text,
+  barcode text,
+  notes text,
+  status text default 'active' check (status = any (array['active'::text, 'consumed'::text, 'expired'::text, 'wasted'::text])),
+  consumed_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  deleted_at timestamptz,
+  list_id uuid references public.lists(id) on delete cascade,
+  constraint positive_quantity check (quantity > 0::numeric)
+);
+
+comment on column public.foods.list_id is 'NULL = personal food (legacy), UUID = shared list food';
+
+create index idx_foods_user_id on public.foods(user_id);
+create index idx_foods_expiry_date on public.foods(expiry_date);
+create index idx_foods_user_expiry on public.foods(user_id, expiry_date) where deleted_at is null;
+create index idx_foods_category on public.foods(category_id);
+create index idx_foods_storage on public.foods(storage_location);
+create index idx_foods_barcode on public.foods(barcode) where barcode is not null;
+create index idx_foods_status on public.foods(status);
+create index idx_foods_name_search on public.foods using gin(to_tsvector('italian'::regconfig, name));
+create index idx_foods_list_id on public.foods(list_id) where list_id is not null;
+create index idx_foods_list_expiry on public.foods(list_id, expiry_date) where deleted_at is null and list_id is not null;
+
+create or replace function public.update_updated_at_column()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger update_foods_updated_at
+  before update on public.foods
+  for each row
+  execute function public.update_updated_at_column();
+
+create or replace function public.get_user_list_ids()
+returns table (list_id uuid)
+language sql
+stable
+security definer
+as $$
+  select distinct lm.list_id
+  from public.list_members lm
+  where lm.user_id = auth.uid();
+$$;
+
+create or replace function public.get_shared_list_member_ids()
+returns table (user_id uuid)
+language sql
+stable
+security definer
+as $$
+  select distinct lm.user_id
+  from public.list_members lm
+  where lm.list_id in (
+    select list_members.list_id
+    from public.list_members
+    where list_members.user_id = auth.uid()
+  );
+$$;
+
+create or replace function public.create_default_list_for_user()
+returns trigger
+language plpgsql
+security definer
+as $$
+declare
+  new_list_id uuid;
+  pending_invite_count integer;
+  list_name text;
+begin
+  select count(*) into pending_invite_count
+  from public.invites
+  where email = new.email
+    and status = 'pending'
+    and expires_at > now();
+
+  if pending_invite_count = 0 then
+    list_name := concat('Lista di ', coalesce(
+      new.raw_user_meta_data->>'full_name',
+      new.email
+    ));
+
+    insert into public.lists (created_by, name)
+    values (new.id, list_name)
+    returning id into new_list_id;
+
+    insert into public.list_members (list_id, user_id)
+    values (new_list_id, new.id);
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.create_personal_list()
+returns table (list_id uuid, success boolean, error_message text)
+language plpgsql
+security definer
+as $$
+declare
+  v_user_id uuid;
+  v_existing_list_id uuid;
+  v_new_list_id uuid;
+  v_list_name text;
+begin
+  v_user_id := auth.uid();
+
+  if v_user_id is null then
+    return query select null::uuid, false, 'User not authenticated'::text;
+    return;
+  end if;
+
+  select lm.list_id into v_existing_list_id
+  from public.list_members lm
+  where lm.user_id = v_user_id
+  limit 1;
+
+  if v_existing_list_id is not null then
+    return query select v_existing_list_id, true, null::text;
+    return;
+  end if;
+
+  select concat('Lista di ', coalesce(
+    u.raw_user_meta_data->>'full_name',
+    u.email
+  ))
+  into v_list_name
+  from auth.users u
+  where u.id = v_user_id;
+
+  insert into public.lists (name, created_by)
+  values (v_list_name, v_user_id)
+  returning id into v_new_list_id;
+
+  insert into public.list_members (list_id, user_id)
+  values (v_new_list_id, v_user_id);
+
+  return query select v_new_list_id, true, null::text;
+exception
+  when others then
+    return query select null::uuid, false, sqlerrm::text;
+end;
+$$;
+
+create or replace function public.delete_user()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  current_user_id uuid;
+begin
+  current_user_id := auth.uid();
+
+  if current_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  delete from public.foods where user_id = current_user_id;
+
+  delete from public.invites
+  where created_by = current_user_id
+     or pending_user_email = (
+       select email from auth.users where id = current_user_id
+     );
+
+  delete from public.list_members where user_id = current_user_id;
+
+  delete from public.lists
+  where created_by = current_user_id
+    and not exists (
+      select 1 from public.list_members where list_id = lists.id
+    );
+
+  delete from auth.users where id = current_user_id;
+end;
+$$;
+
+alter table public.categories enable row level security;
+alter table public.foods enable row level security;
+alter table public.lists enable row level security;
+alter table public.list_members enable row level security;
+alter table public.invites enable row level security;
+
+create policy "Categories are publicly readable"
+  on public.categories for select
+  using (true);
+
+create policy "Users can view lists they belong to"
+  on public.lists for select
+  using (id in (select public.get_user_list_ids()));
+
+create policy "Users can create their own lists"
+  on public.lists for insert
+  with check (auth.uid() = created_by);
+
+create policy "List members can update list details"
+  on public.lists for update
+  using (id in (select public.get_user_list_ids()));
+
+create policy "Users can view members of their lists"
+  on public.list_members for select
+  using (
+    user_id = auth.uid()
+    or list_id in (select public.get_user_list_ids())
+  );
+
+create policy "Users can add themselves to a list via invite"
+  on public.list_members for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can remove themselves from lists"
+  on public.list_members for delete
+  using (auth.uid() = user_id);
+
+create policy "Public can read invites or list members can view their invites"
+  on public.invites for select
+  using (true);
+
+create policy "List members can create invites"
+  on public.invites for insert
+  with check (
+    auth.uid() = created_by
+    and list_id in (select public.get_user_list_ids())
+  );
+
+create policy "System can update invite status"
+  on public.invites for update
+  using (true);
+
+create policy "Users can view foods from their lists"
+  on public.foods for select
+  using (list_id in (
+    select list_members.list_id
+    from public.list_members
+    where list_members.user_id = auth.uid()
+  ));
+
+create policy "Users can insert foods to their lists"
+  on public.foods for insert
+  with check (
+    list_id is not null
+    and list_id in (
+      select list_members.list_id
+      from public.list_members
+      where list_members.user_id = auth.uid()
+    )
+  );
+
+create policy "Users can update foods from their lists"
+  on public.foods for update
+  using (list_id in (
+    select list_members.list_id
+    from public.list_members
+    where list_members.user_id = auth.uid()
+  ))
+  with check (list_id in (
+    select list_members.list_id
+    from public.list_members
+    where list_members.user_id = auth.uid()
+  ));
+
+create policy "Users can delete foods from their lists"
+  on public.foods for delete
+  using (list_id in (
+    select list_members.list_id
+    from public.list_members
+    where list_members.user_id = auth.uid()
+  ));
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'food-images',
+  'food-images',
+  false,
+  5242880,
+  array['image/jpeg', 'image/jpg', 'image/png', 'image/webp']
+)
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+create policy "Users can upload images to own folder or shared list folders"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'food-images'
+    and (
+      (storage.foldername(name))[1] = auth.uid()::text
+      or (storage.foldername(name))[1] in (
+        select user_id::text from public.get_shared_list_member_ids()
+      )
+    )
+  );
+
+create policy "Users can view own images or shared list images"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'food-images'
+    and (
+      (storage.foldername(name))[1] = auth.uid()::text
+      or (storage.foldername(name))[1] in (
+        select user_id::text from public.get_shared_list_member_ids()
+      )
+    )
+  );
+
+create policy "Users can update own images or shared list images"
+  on storage.objects for update to authenticated
+  using (
+    bucket_id = 'food-images'
+    and (
+      (storage.foldername(name))[1] = auth.uid()::text
+      or (storage.foldername(name))[1] in (
+        select user_id::text from public.get_shared_list_member_ids()
+      )
+    )
+  )
+  with check (
+    bucket_id = 'food-images'
+    and (
+      (storage.foldername(name))[1] = auth.uid()::text
+      or (storage.foldername(name))[1] in (
+        select user_id::text from public.get_shared_list_member_ids()
+      )
+    )
+  );
+
+create policy "Users can delete own images or shared list images"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'food-images'
+    and (
+      (storage.foldername(name))[1] = auth.uid()::text
+      or (storage.foldername(name))[1] in (
+        select user_id::text from public.get_shared_list_member_ids()
+      )
+    )
+  );
+
+alter publication supabase_realtime add table public.foods;
+
+grant select on public.categories to anon, authenticated, service_role;
+grant select, insert, update, delete on public.foods to authenticated, service_role;
+grant select, insert, update, delete on public.lists to authenticated, service_role;
+grant select, insert, update, delete on public.list_members to authenticated, service_role;
+grant select, insert, update, delete on public.invites to authenticated, service_role;
+grant select on public.invites to anon;
+
+grant execute on function public.get_user_list_ids() to authenticated, service_role;
+grant execute on function public.get_shared_list_member_ids() to authenticated, service_role;
+grant execute on function public.create_personal_list() to authenticated, service_role;
+grant execute on function public.delete_user() to authenticated, service_role;
+
+revoke execute on function public.delete_user() from anon;

--- a/supabase/migrations/20260228_push_notifications.sql
+++ b/supabase/migrations/20260228_push_notifications.sql
@@ -25,6 +25,9 @@ CREATE POLICY "Users can manage own subscriptions"
 
 CREATE INDEX idx_push_subscriptions_user_id ON public.push_subscriptions(user_id);
 
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_subscriptions TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_subscriptions TO service_role;
+
 -- 2. Tabella notification_preferences
 CREATE TABLE public.notification_preferences (
   id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
@@ -50,6 +53,9 @@ CREATE POLICY "Users can manage own preferences"
   FOR ALL
   USING (auth.uid() = user_id)
   WITH CHECK (auth.uid() = user_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.notification_preferences TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.notification_preferences TO service_role;
 
 -- 3. Funzione per il cron job
 CREATE OR REPLACE FUNCTION public.get_expiring_foods_for_notifications()
@@ -105,6 +111,8 @@ AS $$
     )
   ORDER BY lm.user_id, days_until_expiry ASC;
 $$;
+
+GRANT EXECUTE ON FUNCTION public.get_expiring_foods_for_notifications() TO service_role;
 
 -- 4. pg_cron schedule (eseguire DOPO deploy Edge Functions)
 -- Nota: abilitare pg_cron e pg_net dal Dashboard Supabase > Database > Extensions

--- a/supabase/migrations/20260329_fix_cron_timezone.sql
+++ b/supabase/migrations/20260329_fix_cron_timezone.sql
@@ -3,19 +3,33 @@
 -- pg_cron su Supabase non supporta timezone per-job, quindi usiamo 8:00 UTC
 -- che corrisponde a 10:00 CEST (estate) / 9:00 CET (inverno).
 
-SELECT cron.unschedule('send-expiry-notifications');
+DO $migration$
+BEGIN
+  IF to_regnamespace('cron') IS NULL THEN
+    RAISE NOTICE 'Skipping cron reschedule: pg_cron schema is not available in this environment.';
+    RETURN;
+  END IF;
 
-SELECT cron.schedule(
-  'send-expiry-notifications',
-  '0 8 * * *',
-  $$
-    SELECT net.http_post(
-      url := '<SUPABASE_URL>/functions/v1/send-expiry-notifications',
-      headers := jsonb_build_object(
-        'Content-Type', 'application/json',
-        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret' LIMIT 1)
-      ),
-      body := '{}'::jsonb
-    );
-  $$
-);
+  BEGIN
+    EXECUTE $unschedule$SELECT cron.unschedule('send-expiry-notifications')$unschedule$;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'Existing cron job send-expiry-notifications was not unscheduled: %', SQLERRM;
+  END;
+
+  EXECUTE $cron$
+    SELECT cron.schedule(
+      'send-expiry-notifications',
+      '0 8 * * *',
+      $$
+        SELECT net.http_post(
+          url := '<SUPABASE_URL>/functions/v1/send-expiry-notifications',
+          headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret' LIMIT 1)
+          ),
+          body := '{}'::jsonb
+        );
+      $$
+    )
+  $cron$;
+END $migration$;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config'
 import path from 'path'
 
+const nodeMajor = Number(process.versions.node.split('.')[0])
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -14,6 +16,6 @@ export default defineConfig({
     // its built-in `localStorage` resolves to `undefined` and shadows the one tests
     // expect (vitest#8757). Disabling it lets our setup own the global cleanly and
     // silences the `--localstorage-file` ExperimentalWarning.
-    execArgv: ['--no-experimental-webstorage'],
+    execArgv: nodeMajor >= 25 ? ['--no-experimental-webstorage'] : [],
   },
 })


### PR DESCRIPTION
## Cosa cambia\n- aggiunge CI GitHub Actions, template community, CONTRIBUTING e SECURITY\n- introduce baseline Supabase ricostruttiva in supabase/migrations e README per la cartella migrations storica\n- sposta i tipi Supabase generati in src/lib/supabase.types.ts e tipizza il client\n- documenta Supabase locale e sposta URL/key Supabase fuori da netlify.toml\n- aggiunge GRANT espliciti per push notifications e rende difensiva la migration cron in locale\n\n## Verifiche locali\n- npm run lint (passa con 5 warning Fast Refresh preesistenti)\n- npm run typecheck\n- npm test\n- npm run build\n- supabase start\n- supabase db reset\n- npm run supabase:types\n- smoke Supabase locale: signup, create_personal_list, insert food, insert notification_preferences, delete_user\n\n## Note\n- Demo mode resta tracciata separatamente in #54.\n- Staging Supabase resta opzionale per il limite Free, vedi #12.