### PR TITLE
[codex] Add minimal Playwright E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,50 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      VITE_SUPABASE_URL: http://127.0.0.1:54321
+      VITE_SUPABASE_ANON_KEY: ${{ vars.LOCAL_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' }}
+      E2E_SUPABASE_URL: http://127.0.0.1:54321
+      E2E_SUPABASE_ANON_KEY: ${{ vars.LOCAL_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' }}
+      E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ vars.LOCAL_SUPABASE_SERVICE_ROLE_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU' }}
+      VITE_APP_URL: http://127.0.0.1:5173
+      VITE_APP_NAME: entro
+      VITE_ENABLE_BARCODE_SCANNER: "true"
+      VITE_ENABLE_SWIPE_GESTURES: "true"
+      VITE_ENABLE_SHARED_LISTS: "true"
+      VITE_ENABLE_NOTIFICATIONS: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v2.1.1
+        with:
+          version: 2.108.0
+
+      - name: Start Supabase local stack
+        run: supabase start
+
+      - name: Reset local database
+        run: supabase db reset
+
+      - name: Run Playwright E2E
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 
 # Testing
 /coverage
+/playwright-report
+/test-results
 
 # Production
 dist/
@@ -39,6 +41,7 @@ lerna-debug.log*
 
 # Supabase
 .supabase/
+supabase/.branches/
 
 # Temporary files
 *.tmp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,23 @@ npm run build
 
 La CI GitHub esegue gli stessi controlli su push e pull request.
 
+## Test end-to-end
+
+I test Playwright usano Supabase locale e creano utenti temporanei con la service role key locale standard:
+
+```bash
+supabase start
+supabase db reset
+npx playwright install chromium
+npm run test:e2e
+```
+
+Se preferisci usare Chrome gia' installato invece del browser scaricato da Playwright:
+
+```bash
+E2E_BROWSER_CHANNEL=chrome npm run test:e2e
+```
+
 ## Regole database
 
 Ogni nuova tabella o funzione nello schema `public` deve includere:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'playwright-report', 'test-results'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
@@ -23,6 +23,15 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+    },
+  },
+  {
+    files: ['playwright.config.ts', 'tests/e2e/**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
     },
   },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.7.5",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.7.5",
+      "version": "1.9.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -39,6 +39,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2825,6 +2826,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -9517,6 +9534,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "detect:design": "node scripts/detect-design.mjs",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "test:ci": "vitest run --no-file-parallelism --maxWorkers=1",
     "test:watch": "vitest"
   },
@@ -65,6 +67,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const appUrl = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173'
+const supabaseUrl = process.env.E2E_SUPABASE_URL ?? 'http://127.0.0.1:54321'
+const supabaseAnonKey = process.env.E2E_SUPABASE_ANON_KEY
+  ?? 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'
+const browserChannel = process.env.E2E_BROWSER_CHANNEL
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: appUrl,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1',
+    url: appUrl,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      VITE_SUPABASE_URL: supabaseUrl,
+      VITE_SUPABASE_ANON_KEY: supabaseAnonKey,
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(browserChannel ? { channel: browserChannel } : {}),
+      },
+    },
+  ],
+})

--- a/tests/e2e/food-management.spec.ts
+++ b/tests/e2e/food-management.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test'
+import { createE2EEmail, createE2EUser, deleteE2EUserByEmail } from './helpers/supabase'
+
+const password = 'E2ePassword!2026'
+
+function futureDateInputValue(daysFromToday: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() + daysFromToday)
+  return date.toISOString().slice(0, 10)
+}
+
+test.describe('gestione alimenti', () => {
+  let email: string
+
+  test.beforeEach(async () => {
+    email = createE2EEmail()
+    await createE2EUser(email, password)
+  })
+
+  test.afterEach(async () => {
+    await deleteE2EUserByEmail(email)
+  })
+
+  test('login, aggiunta alimento, modifica quantita e logout', async ({ page }) => {
+    const foodName = `Yogurt E2E ${Date.now()}`
+
+    await page.goto('/login')
+    await page.getByLabel('Email').fill(email)
+    await page.locator('input[name="password"]').fill(password)
+    await page.getByRole('button', { name: 'Accedi' }).click()
+
+    await expect(page.getByRole('heading', { name: /Ciao, Utente E2E!/ })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Alimento' }).click()
+    const addDialog = page.getByRole('dialog', { name: 'Aggiungi Nuovo Alimento' })
+    await expect(addDialog).toBeVisible()
+
+    await addDialog.getByLabel('Nome *').fill(foodName)
+    await addDialog.getByLabel('Categoria *').selectOption({ label: 'Latticini' })
+    await addDialog.getByLabel('Posizione *').selectOption({ label: 'Frigo' })
+    await addDialog.getByLabel('Data di scadenza *').fill(futureDateInputValue(5))
+    await addDialog.getByLabel(/Quantit/).fill('2')
+    await addDialog.getByLabel(/Unit/).selectOption('pz')
+    await addDialog.getByRole('button', { name: 'Aggiungi alimento' }).click()
+
+    await expect(addDialog).toBeHidden()
+    await expect(page.getByRole('heading', { name: new RegExp(foodName) })).toBeVisible()
+    await expect(page.getByText('(2 pz)')).toBeVisible()
+
+    await page.getByRole('button', { name: `Modifica ${foodName}` }).click()
+    const editDialog = page.getByRole('dialog', { name: 'Modifica Alimento' })
+    await expect(editDialog).toBeVisible()
+
+    await editDialog.getByLabel(/Quantit/).fill('3')
+    await editDialog.getByRole('button', { name: 'Salva modifiche' }).click()
+
+    await expect(editDialog).toBeHidden()
+    await expect(page.getByText('(3 pz)')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Menu utente' }).click()
+    await page.getByRole('menuitem', { name: 'Disconnetti' }).click()
+
+    await expect(page).toHaveURL(/\/login$/)
+    await expect(page.getByRole('heading', { name: 'Accedi a entro' })).toBeVisible()
+  })
+})

--- a/tests/e2e/helpers/supabase.ts
+++ b/tests/e2e/helpers/supabase.ts
@@ -1,0 +1,60 @@
+import { createClient } from '@supabase/supabase-js'
+
+const LOCAL_SUPABASE_URL = 'http://127.0.0.1:54321'
+const LOCAL_SERVICE_ROLE_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
+
+const supabaseUrl = process.env.E2E_SUPABASE_URL ?? LOCAL_SUPABASE_URL
+const serviceRoleKey = process.env.E2E_SUPABASE_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_KEY
+
+const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+})
+
+export interface E2EUser {
+  id: string
+  email: string
+  password: string
+}
+
+export function createE2EEmail(): string {
+  return `e2e-${Date.now()}-${crypto.randomUUID()}@example.test`
+}
+
+export async function createE2EUser(email: string, password: string): Promise<E2EUser> {
+  await deleteE2EUserByEmail(email)
+
+  const { data, error } = await adminClient.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { full_name: 'Utente E2E' },
+  })
+
+  if (error) {
+    throw new Error(`Impossibile creare utente E2E. Supabase locale e' avviato? ${error.message}`)
+  }
+  if (!data.user) {
+    throw new Error('Supabase non ha restituito l\'utente E2E creato')
+  }
+
+  return { id: data.user.id, email, password }
+}
+
+export async function deleteE2EUserByEmail(email: string): Promise<void> {
+  const { data, error } = await adminClient.auth.admin.listUsers()
+  if (error) {
+    throw new Error(`Impossibile leggere gli utenti E2E. Supabase locale e' avviato? ${error.message}`)
+  }
+
+  const user = data.users.find((candidate) => candidate.email === email)
+  if (!user) return
+
+  const { error: deleteError } = await adminClient.auth.admin.deleteUser(user.id)
+  if (deleteError) {
+    throw new Error(`Impossibile eliminare l'utente E2E ${email}: ${deleteError.message}`)
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['tests/e2e/**', '**/node_modules/**', '**/dist/**'],
     // Node 25+ enables experimental Web Storage by default; without a backing file
     // its built-in `localStorage` resolves to `undefined` and shadows the one tests
     // expect (vitest#8757). Disabling it lets our setup own the global cleanly and


### PR DESCRIPTION
## Cosa cambia

- Aggiunge Playwright come runner E2E e i comandi `test:e2e` / `test:e2e:ui`.
- Configura il dev server Vite con Supabase locale e supporto opzionale a `E2E_BROWSER_CHANNEL=chrome`.
- Aggiunge un primo spec E2E: login, creazione alimento, modifica quantita dalla modale completa e logout.
- Aggiunge un job GitHub Actions separato `Playwright E2E` che avvia Supabase locale, resetta il DB ed esegue lo spec browser.
- Separa gli spec Playwright da Vitest e documenta il flusso in `CONTRIBUTING.md`.

## Verifiche

- GitHub Actions `Lint, typecheck and test`: verde.
- GitHub Actions `Playwright E2E`: verde, con Supabase locale + `supabase db reset` + Chromium.
- Netlify deploy preview: verde.
- Locale: `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `supabase start`, `supabase db reset` passati.
- Locale sandbox Codex: `npm run test:e2e` non completabile per blocco macOS all’avvio browser (`MachPortRendezvousServer: Permission denied`), ma lo stesso test passa su GitHub Actions Linux.

## Note

- Lo spec non copre ancora il flusso “consuma”: nello stato UI attuale non esiste un controllo diretto e stabile sulle card per impostare `status=consumed`.
- La service role key nel helper e la anon key nel config sono le chiavi standard dello stack Supabase locale, non credenziali di produzione.
