### PR TITLE
[codex] Avoid auth initialization reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - Il client Supabase ora usa i tipi generati come fonte unica invece dei tipi manuali incorporati in `src/lib/supabase.ts`.
 - La documentazione pubblica di deploy privilegia Supabase locale come ambiente di verifica, con staging remoto opzionale.
 - `netlify.toml` non contiene piu' URL/key Supabase pubblicabili: quei valori passano dalle environment variables Netlify.
+- `authStore.initialize()` non ricarica piu' l'intera pagina dopo accettazione invito o creazione lista personale: aggiorna la cache React Query e resta nel flusso SPA.
 
 ### Fixed
 - Aggiunti GRANT espliciti alle tabelle/funzione push notification nella migration dedicata, coerenti con il Data API hardening.

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      gcTime: 1000 * 60 * 60 * 24, // 24 hours — keep data for offline use
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+    mutations: {
+      gcTime: 1000 * 60 * 60 * 24, // 24 hours — keep paused mutations for offline sync
+    },
+  },
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, onlineManager } from '@tanstack/react-query'
+import { onlineManager } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { createIDBPersister, requestPersistentStorage } from './lib/queryPersister'
 import { registerMutationDefaults } from './lib/mutationDefaults'
+import { queryClient } from './lib/queryClient'
 import './index.css'
 import App from './App.tsx'
 
@@ -17,21 +18,6 @@ onlineManager.setEventListener((setOnline) => {
     window.removeEventListener('online', onlineHandler)
     window.removeEventListener('offline', offlineHandler)
   }
-})
-
-// Create React Query client
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60 * 5, // 5 minutes
-      gcTime: 1000 * 60 * 60 * 24, // 24 hours — keep data for offline use
-      refetchOnWindowFocus: false,
-      retry: 1,
-    },
-    mutations: {
-      gcTime: 1000 * 60 * 60 * 24, // 24 hours — keep paused mutations for offline sync
-    },
-  },
 })
 
 // Register mutation defaults so paused mutations can resume after page reload

--- a/src/stores/__tests__/authStore.test.ts
+++ b/src/stores/__tests__/authStore.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Session, User } from '@supabase/supabase-js'
+import { makeLocalStorage } from '../../test/localStorage'
+import { useAuthStore } from '../authStore'
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getCurrentUser: vi.fn(),
+  onAuthStateChange: vi.fn(),
+  getUserList: vi.fn(),
+  acceptInviteByEmail: vi.fn(),
+  createPersonalList: vi.fn(),
+  invalidateQueries: vi.fn(),
+}))
+
+vi.mock('../../lib/auth', () => ({
+  getSession: mocks.getSession,
+  getCurrentUser: mocks.getCurrentUser,
+  onAuthStateChange: mocks.onAuthStateChange,
+}))
+
+vi.mock('../../lib/invites', () => ({
+  getUserList: mocks.getUserList,
+  acceptInviteByEmail: mocks.acceptInviteByEmail,
+  createPersonalList: mocks.createPersonalList,
+}))
+
+vi.mock('../../lib/queryClient', () => ({
+  queryClient: {
+    invalidateQueries: mocks.invalidateQueries,
+  },
+}))
+
+const user = {
+  id: 'user-1',
+  email: 'utente@example.test',
+} as User
+
+const session = {
+  user,
+  access_token: 'access-token',
+  refresh_token: 'refresh-token',
+} as Session
+
+let reload: ReturnType<typeof vi.fn>
+let authCallback: ((event: string, user: User | null, session: Session | null) => void) | null
+
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+
+  throw lastError
+}
+
+function installWindow(hash = '') {
+  reload = vi.fn()
+  vi.stubGlobal('window', {
+    location: {
+      hash,
+      pathname: '/',
+      search: '',
+      href: `http://localhost/${hash}`,
+      reload,
+    },
+    history: {
+      replaceState: vi.fn(),
+    },
+  })
+  vi.stubGlobal('document', { title: 'entro' })
+}
+
+describe('authStore.initialize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authCallback = null
+    localStorage.clear()
+    vi.stubGlobal('sessionStorage', makeLocalStorage())
+    installWindow()
+
+    useAuthStore.setState({
+      user: null,
+      session: null,
+      loading: true,
+      isAuthenticated: false,
+    })
+
+    mocks.getSession.mockResolvedValue(session)
+    mocks.getCurrentUser.mockResolvedValue(user)
+    mocks.onAuthStateChange.mockImplementation((callback) => {
+      authCallback = callback
+      return vi.fn()
+    })
+    mocks.invalidateQueries.mockResolvedValue(undefined)
+  })
+
+  it('marks an authenticated user as initialized when a list already exists', async () => {
+    mocks.getUserList.mockResolvedValue({ list: { id: 'list-1' }, error: null })
+
+    await useAuthStore.getState().initialize()
+
+    await waitForAssertion(() => {
+      expect(sessionStorage.getItem('user_initialized_utente@example.test')).toBe('true')
+    })
+
+    expect(mocks.acceptInviteByEmail).not.toHaveBeenCalled()
+    expect(mocks.createPersonalList).not.toHaveBeenCalled()
+    expect(mocks.invalidateQueries).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('accepts a pending invite, refreshes cached data and avoids a full reload', async () => {
+    mocks.getUserList.mockResolvedValue({ list: null, error: new Error('No list') })
+    mocks.acceptInviteByEmail.mockResolvedValue({ success: true, listId: 'shared-list', error: null })
+
+    await useAuthStore.getState().initialize()
+
+    await waitForAssertion(() => {
+      expect(localStorage.getItem('show_welcome_toast')).toBe('true')
+      expect(mocks.invalidateQueries).toHaveBeenCalled()
+    })
+
+    expect(sessionStorage.getItem('user_initialized_utente@example.test')).toBe('true')
+    expect(mocks.createPersonalList).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('creates a personal list, refreshes cached data and avoids a full reload', async () => {
+    mocks.getUserList.mockResolvedValue({ list: null, error: new Error('No list') })
+    mocks.acceptInviteByEmail.mockResolvedValue({ success: false, listId: null, error: null })
+    mocks.createPersonalList.mockResolvedValue({ success: true, listId: 'personal-list', error: null })
+
+    await useAuthStore.getState().initialize()
+
+    await waitForAssertion(() => {
+      expect(mocks.createPersonalList).toHaveBeenCalled()
+      expect(mocks.invalidateQueries).toHaveBeenCalled()
+    })
+
+    expect(sessionStorage.getItem('user_initialized_utente@example.test')).toBe('true')
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('marks the user as processed when personal list creation fails', async () => {
+    mocks.getUserList.mockResolvedValue({ list: null, error: new Error('No list') })
+    mocks.acceptInviteByEmail.mockResolvedValue({ success: false, listId: null, error: null })
+    mocks.createPersonalList.mockResolvedValue({
+      success: false,
+      listId: null,
+      error: new Error('Create failed'),
+    })
+
+    await useAuthStore.getState().initialize()
+
+    await waitForAssertion(() => {
+      expect(sessionStorage.getItem('user_initialized_utente@example.test')).toBe('true')
+    })
+
+    expect(mocks.invalidateQueries).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('does not run invite or list initialization during password recovery', async () => {
+    mocks.getSession.mockResolvedValue(null)
+    mocks.getCurrentUser.mockResolvedValue(null)
+
+    await useAuthStore.getState().initialize()
+
+    expect(authCallback).toBeTypeOf('function')
+    authCallback!('PASSWORD_RECOVERY', user, session)
+
+    expect(useAuthStore.getState().user).toBe(user)
+    expect(useAuthStore.getState().session).toBe(session)
+    expect(mocks.getUserList).not.toHaveBeenCalled()
+    expect(mocks.acceptInviteByEmail).not.toHaveBeenCalled()
+    expect(mocks.createPersonalList).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { User, Session } from '@supabase/supabase-js'
 import { onAuthStateChange, getSession, getCurrentUser } from '../lib/auth'
 import { acceptInviteByEmail, getUserList, createPersonalList } from '../lib/invites'
+import { queryClient } from '../lib/queryClient'
 
 /**
  * Auth Store State
@@ -28,6 +29,10 @@ interface AuthActions {
  * Combined Auth Store
  */
 type AuthStore = AuthState & AuthActions
+
+async function refreshAuthenticatedData(): Promise<void> {
+  await queryClient.invalidateQueries()
+}
 
 /**
  * Zustand Auth Store with Supabase Auth Integration
@@ -109,11 +114,10 @@ export const useAuthStore = create<AuthStore>((set) => ({
           const { success: inviteAccepted, listId, error } = await acceptInviteByEmail()
 
           if (inviteAccepted && listId) {
-            // Store flag to show toast after reload
+            // Store flag to show toast on the dashboard after cache refresh
             localStorage.setItem('show_welcome_toast', 'true')
-            // Refresh the page to load the new list data
-            // Note: We DON'T set the processed flag here - we'll check again after reload
-            window.location.reload()
+            await refreshAuthenticatedData()
+            sessionStorage.setItem(processedKey, 'true')
             return
           } else if (error) {
             console.error('[authStore] Failed to accept invite:', error.message)
@@ -124,9 +128,8 @@ export const useAuthStore = create<AuthStore>((set) => ({
           const { success: listCreated, error: createError } = await createPersonalList()
 
           if (listCreated) {
-            // Refresh to load the new list
-            // Note: We DON'T set the processed flag here - we'll check again after reload
-            window.location.reload()
+            await refreshAuthenticatedData()
+            sessionStorage.setItem(processedKey, 'true')
           } else {
             console.error('[authStore] Failed to create personal list:', createError)
             // Mark as processed to prevent infinite retries


### PR DESCRIPTION
## Cosa cambia

- Rimuove i `window.location.reload()` da `authStore.initialize()` dopo accettazione invito pendente o creazione lista personale.
- Estrae il `QueryClient` condiviso in `src/lib/queryClient.ts`, così lo store può invalidare la cache React Query fuori da React.
- Aggiunge test unitari di caratterizzazione per i rami lista esistente, invito accettato, lista personale creata, errore creazione lista e `PASSWORD_RECOVERY`.
- Aggiorna `CHANGELOG.md`.

## Verifiche locali

- `npm test -- src/stores/__tests__/authStore.test.ts`
- `npm run lint` (passa con i 5 warning Fast Refresh preesistenti)
- `npm run typecheck`
- `npm run test:ci` (41 file, 233 test)
- `npm run build`

## Note

- Nessuna migrazione Supabase.
- Scope volutamente limitato a `authStore.initialize()`: altri reload nei dialog invito/lista restano fuori da B2.
