### PR TITLE
[codex] Refactor Edge Function CORS helpers

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient, User } from 'https://esm.sh/@supabase/supabase-js@2'
+import { errorResponse } from './cors.ts'
+
+interface AuthenticatedUser {
+  user: User
+}
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.get('Authorization') ?? ''
+  if (!authHeader.startsWith('Bearer ')) return null
+
+  const token = authHeader.slice('Bearer '.length).trim()
+  return token || null
+}
+
+export async function requireAuthenticatedUser(
+  req: Request,
+  supabaseClient: SupabaseClient,
+): Promise<AuthenticatedUser | Response> {
+  const token = getBearerToken(req)
+  if (!token) {
+    return errorResponse(req, 'Missing authorization token', 401)
+  }
+
+  const { data: { user }, error } = await supabaseClient.auth.getUser(token)
+  if (error || !user) {
+    return errorResponse(req, 'Unauthorized', 401)
+  }
+
+  return { user }
+}
+
+export function requireCronSecret(req: Request): Response | null {
+  const token = getBearerToken(req)
+  const cronSecret = Deno.env.get('CRON_SECRET') ?? ''
+
+  if (!cronSecret || token !== cronSecret) {
+    return errorResponse(req, 'Unauthorized', 401)
+  }
+
+  return null
+}

--- a/supabase/functions/_shared/cors.test.ts
+++ b/supabase/functions/_shared/cors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCorsHeaders,
+  handleCorsPreflight,
+  isAllowedOrigin,
+  rejectDisallowedOrigin,
+} from './cors'
+
+describe('edge function CORS helpers', () => {
+  it('allows production and localhost origins', () => {
+    expect(isAllowedOrigin('https://entroapp.it')).toBe(true)
+    expect(isAllowedOrigin('https://www.entroapp.it')).toBe(true)
+    expect(isAllowedOrigin('http://localhost:5173')).toBe(true)
+    expect(isAllowedOrigin('http://127.0.0.1:54321')).toBe(true)
+  })
+
+  it('allows requests without Origin for cron and server-to-server calls', () => {
+    expect(isAllowedOrigin(null)).toBe(true)
+
+    const request = new Request('https://example.com/functions/v1/send-expiry-notifications')
+    expect(rejectDisallowedOrigin(request)).toBeNull()
+  })
+
+  it('echoes the allowed origin instead of using a wildcard', () => {
+    const request = new Request('https://example.com/functions/v1/create-invite', {
+      headers: { Origin: 'https://entroapp.it' },
+    })
+
+    expect(getCorsHeaders(request)['Access-Control-Allow-Origin']).toBe('https://entroapp.it')
+  })
+
+  it('rejects disallowed browser origins before running function logic', async () => {
+    const request = new Request('https://example.com/functions/v1/create-invite', {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://evil.example' },
+    })
+
+    const preflight = handleCorsPreflight(request)
+    expect(preflight?.status).toBe(403)
+
+    const rejection = rejectDisallowedOrigin(request)
+    expect(rejection?.status).toBe(403)
+    await expect(rejection?.json()).resolves.toEqual({ error: 'Origin not allowed' })
+  })
+})

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,112 @@
+const LOCAL_ORIGIN_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/
+
+const DEFAULT_ALLOWED_ORIGINS = new Set([
+  'https://entroapp.it',
+  'https://www.entroapp.it',
+])
+
+function getOptionalEnv(name: string): string | undefined {
+  const deno = (globalThis as {
+    Deno?: { env?: { get: (name: string) => string | undefined } }
+  }).Deno
+
+  return deno?.env?.get(name)
+}
+
+function configuredAllowedOrigins(): string[] {
+  const value = getOptionalEnv('ENTRO_ALLOWED_ORIGINS')
+  if (!value) return []
+
+  return value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+}
+
+export function isAllowedOrigin(origin: string | null): boolean {
+  if (!origin) return true
+  return DEFAULT_ALLOWED_ORIGINS.has(origin)
+    || LOCAL_ORIGIN_PATTERN.test(origin)
+    || configuredAllowedOrigins().includes(origin)
+}
+
+function mergeHeaders(base: HeadersInit, extra?: HeadersInit): Record<string, string> {
+  const headers: Record<string, string> = {}
+
+  new Headers(base).forEach((value, key) => {
+    headers[key] = value
+  })
+
+  if (extra) {
+    new Headers(extra).forEach((value, key) => {
+      headers[key] = value
+    })
+  }
+
+  return headers
+}
+
+export function getCorsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get('Origin')
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    Vary: 'Origin',
+  }
+
+  if (origin && isAllowedOrigin(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin
+  }
+
+  return headers
+}
+
+export function handleCorsPreflight(req: Request): Response | null {
+  if (req.method !== 'OPTIONS') return null
+
+  if (!isAllowedOrigin(req.headers.get('Origin'))) {
+    return new Response(null, {
+      status: 403,
+      headers: { Vary: 'Origin' },
+    })
+  }
+
+  return new Response(null, {
+    status: 204,
+    headers: getCorsHeaders(req),
+  })
+}
+
+export function rejectDisallowedOrigin(req: Request): Response | null {
+  if (isAllowedOrigin(req.headers.get('Origin'))) return null
+  return jsonResponse(req, { error: 'Origin not allowed' }, { status: 403 })
+}
+
+export function handleCors(req: Request): Response | null {
+  return handleCorsPreflight(req) ?? rejectDisallowedOrigin(req)
+}
+
+export function jsonResponse(
+  req: Request,
+  body: unknown,
+  init: ResponseInit = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: mergeHeaders(
+      {
+        ...getCorsHeaders(req),
+        'Content-Type': 'application/json',
+      },
+      init.headers,
+    ),
+  })
+}
+
+export function errorResponse(
+  req: Request,
+  error: string,
+  status = 500,
+): Response {
+  return jsonResponse(req, { error }, { status })
+}

--- a/supabase/functions/_shared/supabase.ts
+++ b/supabase/functions/_shared/supabase.ts
@@ -1,0 +1,21 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+export function createServiceClient() {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase service environment')
+  }
+
+  return createClient(
+    supabaseUrl,
+    serviceRoleKey,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  )
+}

--- a/supabase/functions/accept-invite/index.ts
+++ b/supabase/functions/accept-invite/index.ts
@@ -2,61 +2,30 @@
 // Accepts invite by short code and adds user to shared list (requires authentication)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { handleCors, jsonResponse, errorResponse } from '../_shared/cors.ts'
+import { requireAuthenticatedUser } from '../_shared/auth.ts'
+import { createServiceClient } from '../_shared/supabase.ts'
 
 interface AcceptRequest {
   shortCode: string
 }
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
+  const corsResponse = handleCors(req)
+  if (corsResponse) return corsResponse
 
   try {
-    const supabaseClient = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-      {
-        auth: {
-          autoRefreshToken: false,
-          persistSession: false,
-        },
-      }
-    )
+    const supabaseClient = createServiceClient()
 
-    // Get authenticated user
-    const token = req.headers.get('Authorization')?.replace('Bearer ', '')
-    if (!token) {
-      return new Response(
-        JSON.stringify({ error: 'Missing authorization token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    const { data: { user }, error: userError } = await supabaseClient.auth.getUser(token)
-    if (userError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    const userId = user.id
+    const auth = await requireAuthenticatedUser(req, supabaseClient)
+    if (auth instanceof Response) return auth
+    const userId = auth.user.id
 
     // Parse request
     const { shortCode }: AcceptRequest = await req.json()
 
     if (!shortCode) {
-      return new Response(
-        JSON.stringify({ error: 'Short code required' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Short code required', 400)
     }
 
     // Lookup invite
@@ -67,18 +36,12 @@ serve(async (req) => {
       .single()
 
     if (inviteError || !inviteData) {
-      return new Response(
-        JSON.stringify({ error: 'Invite not found' }),
-        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Invite not found', 404)
     }
 
     // Check status
     if (inviteData.status !== 'pending') {
-      return new Response(
-        JSON.stringify({ error: 'Invite already used or expired' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Invite already used or expired', 400)
     }
 
     // Check expiry
@@ -89,10 +52,7 @@ serve(async (req) => {
         .update({ status: 'expired' })
         .eq('id', inviteData.id)
 
-      return new Response(
-        JSON.stringify({ error: 'Invite expired' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Invite expired', 400)
     }
 
     // NO EMAIL MATCH CHECK - anyone with code can use it!
@@ -115,14 +75,12 @@ serve(async (req) => {
         })
         .eq('id', inviteData.id)
 
-      return new Response(
-        JSON.stringify({
+      return jsonResponse(
+        req,
+        {
           success: true,
           listId: inviteData.list_id,
-        }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        }
+        },
       )
     }
 
@@ -136,10 +94,7 @@ serve(async (req) => {
 
     if (memberError) {
       console.error('Error adding member:', memberError)
-      return new Response(
-        JSON.stringify({ error: 'Failed to add member' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Failed to add member', 500)
     }
 
     // Mark invite as accepted
@@ -151,20 +106,15 @@ serve(async (req) => {
       })
       .eq('id', inviteData.id)
 
-    return new Response(
-      JSON.stringify({
+    return jsonResponse(
+      req,
+      {
         success: true,
         listId: inviteData.list_id,
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
+      },
     )
   } catch (error) {
     console.error('Unexpected error:', error)
-    return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    )
+    return errorResponse(req, 'Internal server error', 500)
   }
 })

--- a/supabase/functions/create-invite/index.ts
+++ b/supabase/functions/create-invite/index.ts
@@ -2,13 +2,10 @@
 // Generates short invite code for anonymous sharing
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { customAlphabet } from 'https://esm.sh/nanoid@4'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { handleCors, jsonResponse, errorResponse } from '../_shared/cors.ts'
+import { requireAuthenticatedUser } from '../_shared/auth.ts'
+import { createServiceClient } from '../_shared/supabase.ts'
 
 interface InviteRequest {
   listId: string  // SOLO questo, no email!
@@ -27,49 +24,21 @@ const generateToken = customAlphabet(
 )
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
+  const corsResponse = handleCors(req)
+  if (corsResponse) return corsResponse
 
   try {
-    const supabaseClient = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-      {
-        auth: {
-          autoRefreshToken: false,
-          persistSession: false,
-        },
-      }
-    )
+    const supabaseClient = createServiceClient()
 
-    // Get authenticated user
-    const token = req.headers.get('Authorization')?.replace('Bearer ', '')
-    if (!token) {
-      return new Response(
-        JSON.stringify({ error: 'Missing authorization token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    const { data: { user }, error: userError } = await supabaseClient.auth.getUser(token)
-    if (userError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    const userId = user.id
+    const auth = await requireAuthenticatedUser(req, supabaseClient)
+    if (auth instanceof Response) return auth
+    const userId = auth.user.id
 
     // Parse request - SOLO listId
     const { listId }: InviteRequest = await req.json()
 
     if (!listId) {
-      return new Response(
-        JSON.stringify({ error: 'listId is required' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'listId is required', 400)
     }
 
     // Check user is member of list
@@ -81,10 +50,7 @@ serve(async (req) => {
       .single()
 
     if (memberError || !memberData) {
-      return new Response(
-        JSON.stringify({ error: 'You are not a member of this list' }),
-        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'You are not a member of this list', 403)
     }
 
     // Generate unique short code with collision handling
@@ -106,10 +72,7 @@ serve(async (req) => {
     }
 
     if (attempts === maxAttempts) {
-      return new Response(
-        JSON.stringify({ error: 'Failed to generate unique code' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Failed to generate unique code', 500)
     }
 
     // Set expiry (7 days)
@@ -133,27 +96,19 @@ serve(async (req) => {
 
     if (inviteError) {
       console.error('Error creating invite:', inviteError)
-      return new Response(
-        JSON.stringify({ error: 'Failed to create invite' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Failed to create invite', 500)
     }
 
     // Return SOLO shortCode
-    return new Response(
-      JSON.stringify({
+    return jsonResponse(
+      req,
+      {
         success: true,
         shortCode: shortCode,
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
+      },
     )
   } catch (error) {
     console.error('Unexpected error:', error)
-    return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    )
+    return errorResponse(req, 'Internal server error', 500)
   }
 })

--- a/supabase/functions/register-push/index.ts
+++ b/supabase/functions/register-push/index.ts
@@ -1,10 +1,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { handleCors, jsonResponse, errorResponse } from '../_shared/cors.ts'
+import { requireAuthenticatedUser } from '../_shared/auth.ts'
+import { createServiceClient } from '../_shared/supabase.ts'
 
 interface SubscribeRequest {
   action: 'subscribe' | 'unsubscribe'
@@ -17,36 +14,22 @@ interface SubscribeRequest {
 }
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
+  const corsResponse = handleCors(req)
+  if (corsResponse) return corsResponse
 
   try {
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-      { auth: { autoRefreshToken: false, persistSession: false } }
-    )
+    const supabase = createServiceClient()
 
     // Autenticare l'utente
-    const token = req.headers.get('Authorization')?.replace('Bearer ', '')
-    if (!token) {
-      return new Response(JSON.stringify({ error: 'Missing authorization' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
-    }
-
-    const { data: { user }, error: userError } = await supabase.auth.getUser(token)
-    if (userError || !user) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
-    }
+    const auth = await requireAuthenticatedUser(req, supabase)
+    if (auth instanceof Response) return auth
+    const user = auth.user
 
     const body: SubscribeRequest = await req.json()
 
     if (body.action === 'subscribe') {
       if (!body.subscription) {
-        return new Response(JSON.stringify({ error: 'Subscription data required' }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+        return errorResponse(req, 'Subscription data required', 400)
       }
 
       // Upsert subscription (gestisce re-subscribe dello stesso device)
@@ -69,29 +52,24 @@ serve(async (req) => {
         .upsert({ user_id: user.id, enabled: true },
           { onConflict: 'user_id', ignoreDuplicates: true })
 
-      return new Response(JSON.stringify({ success: true }),
-        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+      return jsonResponse(req, { success: true })
     }
 
     if (body.action === 'unsubscribe') {
       const endpoint = body.endpoint || body.subscription?.endpoint
       if (!endpoint) {
-        return new Response(JSON.stringify({ error: 'Endpoint required' }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+        return errorResponse(req, 'Endpoint required', 400)
       }
 
       await supabase.from('push_subscriptions').delete()
         .eq('user_id', user.id).eq('endpoint', endpoint)
 
-      return new Response(JSON.stringify({ success: true }),
-        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+      return jsonResponse(req, { success: true })
     }
 
-    return new Response(JSON.stringify({ error: 'Invalid action' }),
-      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    return errorResponse(req, 'Invalid action', 400)
   } catch (error) {
     console.error('Error:', error)
-    return new Response(JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    return errorResponse(req, 'Internal server error', 500)
   }
 })

--- a/supabase/functions/send-expiry-notifications/index.ts
+++ b/supabase/functions/send-expiry-notifications/index.ts
@@ -1,17 +1,13 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { ApplicationServer, importVapidKeys } from '@negrel/webpush'
 import type { PushSubscription as WebPushSubscription } from '@negrel/webpush'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { handleCors, jsonResponse, errorResponse } from '../_shared/cors.ts'
+import { requireCronSecret } from '../_shared/auth.ts'
+import { createServiceClient } from '../_shared/supabase.ts'
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
+  const corsResponse = handleCors(req)
+  if (corsResponse) return corsResponse
 
   /**
    * Autenticazione cron job: pg_cron → Vault → Edge Function
@@ -34,21 +30,11 @@ serve(async (req) => {
    * - Migration: supabase/migrations/20260228_push_notifications.sql (sezione 4)
    * - Vault setup: SELECT vault.create_secret('<secret>', 'cron_secret', '...')
    */
-  const authHeader = req.headers.get('Authorization') ?? ''
-  const token = authHeader.replace('Bearer ', '')
-  const cronSecret = Deno.env.get('CRON_SECRET') ?? ''
-
-  if (!cronSecret || token !== cronSecret) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }),
-      { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
-  }
+  const cronAuthError = requireCronSecret(req)
+  if (cronAuthError) return cronAuthError
 
   try {
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-      { auth: { autoRefreshToken: false, persistSession: false } }
-    )
+    const supabase = createServiceClient()
 
     // Inizializzare Web Push con VAPID keys (JWK format)
     const vapidKeysJson = JSON.parse(Deno.env.get('VAPID_KEYS') ?? '{}')
@@ -64,8 +50,7 @@ serve(async (req) => {
 
     if (queryError) throw queryError
     if (!expiringFoods || expiringFoods.length === 0) {
-      return new Response(JSON.stringify({ success: true, sent: 0 }),
-        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+      return jsonResponse(req, { success: true, sent: 0 })
     }
 
     // 2. Raggruppare per utente
@@ -160,11 +145,9 @@ serve(async (req) => {
       await supabase.from('push_subscriptions').delete().eq('endpoint', endpoint)
     }
 
-    return new Response(JSON.stringify({ success: true, sent: totalSent, staleRemoved: staleEndpoints.length }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    return jsonResponse(req, { success: true, sent: totalSent, staleRemoved: staleEndpoints.length })
   } catch (error) {
     console.error('Cron job error:', error)
-    return new Response(JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    return errorResponse(req, 'Internal server error', 500)
   }
 })

--- a/supabase/functions/validate-invite/index.ts
+++ b/supabase/functions/validate-invite/index.ts
@@ -2,41 +2,24 @@
 // Validates invite by short code (public endpoint, no auth required)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { handleCors, jsonResponse, errorResponse } from '../_shared/cors.ts'
+import { createServiceClient } from '../_shared/supabase.ts'
 
 interface ValidateRequest {
   shortCode: string
 }
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
+  const corsResponse = handleCors(req)
+  if (corsResponse) return corsResponse
 
   try {
-    const supabaseService = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-      {
-        auth: {
-          autoRefreshToken: false,
-          persistSession: false,
-        },
-      }
-    )
+    const supabaseService = createServiceClient()
 
     const { shortCode }: ValidateRequest = await req.json()
 
     if (!shortCode) {
-      return new Response(
-        JSON.stringify({ error: 'Short code required' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      return errorResponse(req, 'Short code required', 400)
     }
 
     // Lookup invite
@@ -47,30 +30,26 @@ serve(async (req) => {
       .single()
 
     if (inviteError || !inviteData) {
-      return new Response(
-        JSON.stringify({
+      return jsonResponse(
+        req,
+        {
           valid: false,
           invite: null,
           error: 'Invite not found',
-        }),
-        {
-          status: 404,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        }
+        },
+        { status: 404 },
       )
     }
 
     // Check status
     if (inviteData.status !== 'pending') {
-      return new Response(
-        JSON.stringify({
+      return jsonResponse(
+        req,
+        {
           valid: false,
           invite: null,
           error: 'Invite already used or expired',
-        }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        }
+        },
       )
     }
 
@@ -85,15 +64,13 @@ serve(async (req) => {
         .update({ status: 'expired' })
         .eq('id', inviteData.id)
 
-      return new Response(
-        JSON.stringify({
+      return jsonResponse(
+        req,
+        {
           valid: false,
           invite: null,
           error: 'Invite expired',
-        }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        }
+        },
       )
     }
 
@@ -119,24 +96,19 @@ serve(async (req) => {
     }
 
     // Return valid invite - NO email in response
-    return new Response(
-      JSON.stringify({
+    return jsonResponse(
+      req,
+      {
         valid: true,
         invite: {
           listName: listName,
           creatorName: creatorName,
           expiresAt: inviteData.expires_at,
         },
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
+      },
     )
   } catch (error) {
     console.error('Unexpected error:', error)
-    return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    )
+    return errorResponse(req, 'Internal server error', 500)
   }
 })


### PR DESCRIPTION
## Summary

Refactors the Supabase Edge Functions to share transport/auth boilerplate while keeping the existing business behavior intact.

- Adds `supabase/functions/_shared/` helpers for restricted CORS, JSON responses, service-role client creation, user JWT validation, and cron-secret validation.
- Removes per-function wildcard CORS headers from `create-invite`, `accept-invite`, `validate-invite`, `register-push`, and `send-expiry-notifications`.
- Keeps trust models separate: authenticated user JWT endpoints, public invite validation, and cron secret endpoint.
- Adds Vitest coverage for the CORS helper behavior.

## Notes

Default allowed browser origins are `https://entroapp.it`, `https://www.entroapp.it`, and localhost/127.0.0.1 development origins. Temporary staging or preview origins can be added with `ENTRO_ALLOWED_ORIGINS` instead of reintroducing `*`.

No production Supabase deploy was performed in this PR. Deploy still needs a temporary `SUPABASE_ACCESS_TOKEN` and follow-up smoke tests for invite flow and push notifications.

## Validation

- `npm run lint` passes with 5 existing Fast Refresh warnings.
- `npm run typecheck`
- `npm run test:ci` (42 files, 237 tests)
- `npm run build`
- `SUPABASE_TELEMETRY_DISABLED=1 supabase --version` -> 2.108.0
- `supabase functions serve --no-verify-jwt --env-file .env.local` could not run because this Codex session cannot access the Docker socket, even with Docker Desktop open.
