### PR TITLE
[codex] Close consolidation documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - CI GitHub Actions con lint, typecheck, test e build su push/PR.
 - Documenti contributor/community: `CONTRIBUTING.md`, `SECURITY.md`, template issue e template PR.
 - Tipi Supabase generati in `src/lib/supabase.types.ts` con comando `npm run supabase:types`.
+- E2E Playwright minimi in CI su stack Supabase locale.
+- Issue GitHub autosufficienti per backlog prodotto: demo mode (#54), API/MCP agenti (#51), report anti-spreco (#60), shelf-life (#61), OCR scadenza (#62), lista spesa (#63), PWA avanzata (#64), import dati (#65).
 
 ### Changed
 - Il client Supabase ora usa i tipi generati come fonte unica invece dei tipi manuali incorporati in `src/lib/supabase.ts`.
 - La documentazione pubblica di deploy privilegia Supabase locale come ambiente di verifica, con staging remoto opzionale.
 - `netlify.toml` non contiene piu' URL/key Supabase pubblicabili: quei valori passano dalle environment variables Netlify.
 - `authStore.initialize()` non ricarica piu' l'intera pagina dopo accettazione invito o creazione lista personale: aggiorna la cache React Query e resta nel flusso SPA.
+- Le Supabase Edge Functions condividono helper `_shared/` per CORS ristretto, risposte JSON, client service-role e validazione auth/cron secret.
 
 ### Fixed
 - Aggiunti GRANT espliciti alle tabelle/funzione push notification nella migration dedicata, coerenti con il Data API hardening.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ src/
 ├── pages/              # Route pages
 ├── lib/                # Config Supabase, persistenza offline, push notifications
 ├── sw.ts               # Service worker custom (cache, push handlers)
-└── supabase/functions/ # Edge Functions (register-push, send-expiry-notifications)
+└── supabase/functions/ # Edge Functions + helper condivisi (_shared)
 ```
 
 ### Scelte tecniche

--- a/docs/guides/DEPLOY.md
+++ b/docs/guides/DEPLOY.md
@@ -150,7 +150,7 @@ Le impostazioni non sensibili possono restare in `netlify.toml`: la documentazio
 ### Supabase Connection Error
 - Verifica `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`
 - Controlla che il progetto Supabase sia attivo
-- Verifica le CORS policies su Supabase (dovrebbe essere `*` di default)
+- Verifica le Edge Functions: Entro usa CORS ristretto a `https://entroapp.it`, `https://www.entroapp.it`, localhost/127.0.0.1 e agli origin esplicitati in `ENTRO_ALLOWED_ORIGINS`. Non ripristinare `Access-Control-Allow-Origin: *`.
 
 ### 404 Errors on Refresh
 - Verifica che `netlify.toml` contenga il redirect rule


### PR DESCRIPTION
## Summary

Completes the tracked public documentation closeout for the July consolidation plan.

- Updates `CHANGELOG.md` with B1/B3/Fase C outcomes.
- Updates README's project tree to reflect shared Edge Function helpers.
- Updates deploy troubleshooting to document restricted Edge Function CORS instead of wildcard CORS.

## Notes

The local/private docs and the canonical gitignored plan were also updated on disk, but are not part of this repo PR because those paths are ignored.

## Validation

- Grep check for stale current-doc terms: old Vite wording, wildcard CORS guidance, pending B3/deploy wording.
- Documentation-only change; no runtime checks required.
