### PR TITLE
fix: follow-up review consolidamento + release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
-## [Unreleased]
+## [1.10.0] - 2026-07-06
 
 ### Added
 - Baseline Supabase ricostruttiva in `supabase/migrations/` per rendere `supabase db reset` riproducibile da clone pulito.
@@ -14,6 +14,7 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - Tipi Supabase generati in `src/lib/supabase.types.ts` con comando `npm run supabase:types`.
 - E2E Playwright minimi in CI su stack Supabase locale.
 - Issue GitHub autosufficienti per backlog prodotto: demo mode (#54), API/MCP agenti (#51), report anti-spreco (#60), shelf-life (#61), OCR scadenza (#62), lista spesa (#63), PWA avanzata (#64), import dati (#65).
+- Test unit per gli helper auth/cron delle Edge Functions (`_shared/auth.ts`) e per il toast di benvenuto invito.
 
 ### Changed
 - Il client Supabase ora usa i tipi generati come fonte unica invece dei tipi manuali incorporati in `src/lib/supabase.ts`.
@@ -21,10 +22,13 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - `netlify.toml` non contiene piu' URL/key Supabase pubblicabili: quei valori passano dalle environment variables Netlify.
 - `authStore.initialize()` non ricarica piu' l'intera pagina dopo accettazione invito o creazione lista personale: aggiorna la cache React Query e resta nel flusso SPA.
 - Le Supabase Edge Functions condividono helper `_shared/` per CORS ristretto, risposte JSON, client service-role e validazione auth/cron secret.
+- `FoodForm` valida a runtime i valori DB `storage_location`/`quantity_unit` in modifica (parsing Zod) invece di cast senza controllo.
 
 ### Fixed
 - Aggiunti GRANT espliciti alle tabelle/funzione push notification nella migration dedicata, coerenti con il Data API hardening.
 - La migration cron notification ora e' difensiva quando `pg_cron` non e' disponibile in locale.
+- Il toast di benvenuto dopo l'accettazione di un invito compare anche quando la dashboard e' gia' montata (regressione introdotta rimuovendo il reload); prima poteva apparire solo alla visita successiva.
+- L'export dati GDPR mantiene `null` esplicito per `joined_at` mancante invece di sostituirlo con la stringa `'N/A'`.
 
 ## [1.9.0] - 2026-07-02
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -9,3 +9,16 @@ supabase/migrations/
 ```
 
 Non aggiungere nuove migration in questa cartella. Se serve recuperare contesto storico, leggere questi file e poi portare la modifica nella catena canonica in `supabase/migrations/`.
+
+## Regola: le migration applicate sono immutabili
+
+Una volta che una migration è stata applicata in produzione, il suo file **non
+va più modificato**. Il repo deve riflettere cosa è realmente girato sul
+database, altrimenti la history non è più auditabile. Ogni correzione (GRANT
+mancanti, fix difensivi, ecc.) va in una **nuova migration additiva** in
+`supabase/migrations/`, non con un edit in-place della migration già applicata.
+
+Eccezione storica: la baseline `20260109_baseline_core_schema.sql` è una
+ricostruzione in sola lettura (mai applicata in produzione) e alcune migration
+push sono state ritoccate durante il consolidamento 2026-07 prima che la regola
+fosse formalizzata. Da qui in avanti vale l'immutabilità.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -4,7 +4,12 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { format } from 'date-fns'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
-import { foodFormSchema, type FoodFormData } from '@/lib/validations/food.schemas'
+import {
+  foodFormSchema,
+  storageLocationEnum,
+  quantityUnitEnum,
+  type FoodFormData,
+} from '@/lib/validations/food.schemas'
 import { useCategories } from '@/hooks/useFoods'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -129,9 +134,11 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
         name: initialData.name,
         category_id: initialData.category_id,
         expiry_date: format(new Date(initialData.expiry_date), 'yyyy-MM-dd'),
-        storage_location: initialData.storage_location as FoodFormData['storage_location'],
+        // Narrow the DB text columns at runtime instead of casting blindly:
+        // values are constrained by CHECK, so parse only fails on real corruption.
+        storage_location: storageLocationEnum.parse(initialData.storage_location),
         quantity: initialData.quantity,
-        quantity_unit: initialData.quantity_unit as FoodFormData['quantity_unit'],
+        quantity_unit: quantityUnitEnum.nullable().parse(initialData.quantity_unit),
         notes: initialData.notes,
         image_url: initialData.image_url,
       })

--- a/src/hooks/__tests__/useWelcomeToast.test.tsx
+++ b/src/hooks/__tests__/useWelcomeToast.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { toast } from 'sonner'
+import { useWelcomeToast } from '../useWelcomeToast'
+import { notifyWelcomeToast, WELCOME_TOAST_FLAG } from '../../lib/welcomeToast'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn() },
+}))
+
+function Harness() {
+  useWelcomeToast()
+  return null
+}
+
+describe('useWelcomeToast', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.mocked(toast.success).mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('mostra il toast e pulisce il flag quando e\' gia\' presente al mount', () => {
+    localStorage.setItem(WELCOME_TOAST_FLAG, 'true')
+
+    render(<Harness />)
+
+    expect(toast.success).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem(WELCOME_TOAST_FLAG)).toBeNull()
+  })
+
+  it('mostra il toast quando il flag viene impostato dopo il mount', () => {
+    render(<Harness />)
+    expect(toast.success).not.toHaveBeenCalled()
+
+    notifyWelcomeToast()
+
+    expect(toast.success).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem(WELCOME_TOAST_FLAG)).toBeNull()
+  })
+
+  it('non mostra nulla senza il flag', () => {
+    render(<Harness />)
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('non mostra il toast due volte per un singolo invito', () => {
+    render(<Harness />)
+
+    notifyWelcomeToast()
+    // Un secondo evento senza nuovo invito non deve ri-mostrare il toast
+    window.dispatchEvent(new Event('entro:welcome-toast'))
+
+    expect(toast.success).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useWelcomeToast.ts
+++ b/src/hooks/useWelcomeToast.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+import { WELCOME_TOAST_EVENT, WELCOME_TOAST_FLAG } from '../lib/welcomeToast'
+
+/**
+ * Mostra una sola volta il toast "invito accettato".
+ *
+ * Il flag viene impostato da `authStore` dopo l'accettazione dell'invito. Se il
+ * flag e' gia' presente al mount lo consumiamo subito (redirect da conferma
+ * email); se viene impostato mentre la dashboard e' gia' montata reagiamo
+ * all'evento che `notifyWelcomeToast` emette. Prima il toast compariva solo
+ * grazie al reload rimosso in B2, quindi senza questo listener sarebbe apparso
+ * solo alla visita successiva.
+ */
+export function useWelcomeToast(): void {
+  useEffect(() => {
+    const consume = () => {
+      if (localStorage.getItem(WELCOME_TOAST_FLAG) !== 'true') return
+      localStorage.removeItem(WELCOME_TOAST_FLAG)
+      toast.success('Benvenuto! Ora puoi vedere la lista condivisa', {
+        duration: 5000,
+      })
+    }
+
+    consume()
+    window.addEventListener(WELCOME_TOAST_EVENT, consume)
+    return () => window.removeEventListener(WELCOME_TOAST_EVENT, consume)
+  }, [])
+}

--- a/src/lib/dataExport.ts
+++ b/src/lib/dataExport.ts
@@ -28,7 +28,7 @@ export interface ExportData {
     createdBy: string | null
     members: Array<{
       userId: string
-      joinedAt: string
+      joinedAt: string | null
     }>
   }
   note: string
@@ -86,7 +86,7 @@ export async function exportUserData(): Promise<{ success: boolean; error: Error
       listId: null as string | null,
       listName: null as string | null,
       createdBy: null as string | null,
-      members: [] as Array<{ userId: string; joinedAt: string }>,
+      members: [] as Array<{ userId: string; joinedAt: string | null }>,
     }
 
     try {
@@ -100,7 +100,8 @@ export async function exportUserData(): Promise<{ success: boolean; error: Error
         const { members } = await getListMembers(list.id)
         listData.members = members.map((m) => ({
           userId: m.user_id,
-          joinedAt: m.joined_at ?? 'N/A',
+          // Keep null explicit: this is a machine-readable GDPR export.
+          joinedAt: m.joined_at,
         }))
       }
     } catch (listError) {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -16,7 +16,9 @@ if (!supabaseUrl || !supabaseAnonKey) {
  * Create Supabase client with auth configuration.
  *
  * `detectSessionInUrl: true` is required for password reset, magic link and
- * OAuth redirects because Supabase reads auth tokens from URL fragments.
+ * OAuth redirects because Supabase reads auth tokens from URL fragments. As a
+ * side effect it can auto-login from any URL carrying an active token (even in
+ * incognito); `authStore` guards and logs this — do not disable it.
  */
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {
@@ -28,6 +30,7 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     params: {
       eventsPerSecond: 10,
     },
+    // 15s instead of the default 25s: faster disconnect detection on mobile.
     heartbeatIntervalMs: 15000,
     timeout: 20000,
   },

--- a/src/lib/welcomeToast.ts
+++ b/src/lib/welcomeToast.ts
@@ -1,0 +1,16 @@
+/**
+ * Contratto per il toast di benvenuto mostrato dopo l'accettazione di un invito.
+ *
+ * `authStore` accetta l'invito e segnala il toast; la dashboard lo consuma.
+ * L'accettazione puo' avvenire prima che la dashboard sia montata (redirect da
+ * conferma email) oppure mentre e' gia' montata (invito processato dopo il
+ * render): il flag in localStorage copre il primo caso, l'evento il secondo.
+ */
+export const WELCOME_TOAST_FLAG = 'show_welcome_toast'
+export const WELCOME_TOAST_EVENT = 'entro:welcome-toast'
+
+/** Segnala che il toast di benvenuto va mostrato alla prossima occasione. */
+export function notifyWelcomeToast(): void {
+  localStorage.setItem(WELCOME_TOAST_FLAG, 'true')
+  window.dispatchEvent(new Event(WELCOME_TOAST_EVENT))
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,9 +1,9 @@
-import { useState, useMemo, lazy, Suspense, useEffect } from 'react'
+import { useState, useMemo, lazy, Suspense } from 'react'
 import { FoodModals } from '../components/foods/FoodModals'
 import { useSearchParams } from 'react-router-dom'
-import { toast } from 'sonner'
 import { Plus, ShoppingBasket, X, List, Calendar } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
+import { useWelcomeToast } from '../hooks/useWelcomeToast'
 import { useDocumentMeta } from '../hooks/useDocumentMeta'
 import { useFoods, useCategories } from '../hooks/useFoods'
 import { useFoodFormDialog } from '../hooks/useFoodFormDialog'
@@ -58,15 +58,7 @@ export function DashboardPage() {
   useRealtimeFoods()
 
   // Show welcome toast if user just accepted an invite
-  useEffect(() => {
-    const showWelcome = localStorage.getItem('show_welcome_toast')
-    if (showWelcome === 'true') {
-      localStorage.removeItem('show_welcome_toast')
-      toast.success('Benvenuto! Ora puoi vedere la lista condivisa', {
-        duration: 5000,
-      })
-    }
-  }, [])
+  useWelcomeToast()
 
   // Track instruction card visibility
   const [showInstructionCard, setShowInstructionCard] = useState(() => {

--- a/src/stores/__tests__/authStore.test.ts
+++ b/src/stores/__tests__/authStore.test.ts
@@ -74,6 +74,8 @@ function installWindow(hash = '') {
     history: {
       replaceState: vi.fn(),
     },
+    // authStore signals the welcome toast via a window event (see welcomeToast.ts)
+    dispatchEvent: vi.fn(),
   })
   vi.stubGlobal('document', { title: 'entro' })
 }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -3,6 +3,7 @@ import type { User, Session } from '@supabase/supabase-js'
 import { onAuthStateChange, getSession, getCurrentUser } from '../lib/auth'
 import { acceptInviteByEmail, getUserList, createPersonalList } from '../lib/invites'
 import { queryClient } from '../lib/queryClient'
+import { notifyWelcomeToast } from '../lib/welcomeToast'
 
 /**
  * Auth Store State
@@ -114,8 +115,9 @@ export const useAuthStore = create<AuthStore>((set) => ({
           const { success: inviteAccepted, listId, error } = await acceptInviteByEmail()
 
           if (inviteAccepted && listId) {
-            // Store flag to show toast on the dashboard after cache refresh
-            localStorage.setItem('show_welcome_toast', 'true')
+            // Signal the dashboard to show the welcome toast. Works whether the
+            // dashboard is already mounted (event) or mounts later (flag).
+            notifyWelcomeToast()
             await refreshAuthenticatedData()
             sessionStorage.setItem(processedKey, 'true')
             return

--- a/supabase/functions/_shared/auth.test.ts
+++ b/supabase/functions/_shared/auth.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { requireAuthenticatedUser, requireCronSecret } from './auth'
+
+type DenoGlobal = { env?: { get: (name: string) => string | undefined } }
+
+function stubDenoEnv(values: Record<string, string>): void {
+  ;(globalThis as { Deno?: DenoGlobal }).Deno = {
+    env: { get: (name: string) => values[name] },
+  }
+}
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/functions/v1/create-invite', {
+    method: 'POST',
+    headers,
+  })
+}
+
+describe('requireAuthenticatedUser', () => {
+  it('returns 401 when the Authorization header is missing', async () => {
+    const client = { auth: { getUser: vi.fn() } }
+
+    const result = await requireAuthenticatedUser(makeRequest(), client as never)
+
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(401)
+    expect(client.auth.getUser).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when the token is present but invalid', async () => {
+    const client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: new Error('bad token'),
+        }),
+      },
+    }
+
+    const result = await requireAuthenticatedUser(
+      makeRequest({ Authorization: 'Bearer bogus' }),
+      client as never,
+    )
+
+    expect((result as Response).status).toBe(401)
+    expect(client.auth.getUser).toHaveBeenCalledWith('bogus')
+  })
+
+  it('returns the user for a valid token', async () => {
+    const user = { id: 'user-123', email: 'a@b.it' }
+    const client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user }, error: null }),
+      },
+    }
+
+    const result = await requireAuthenticatedUser(
+      makeRequest({ Authorization: 'Bearer good' }),
+      client as never,
+    )
+
+    expect(result).toEqual({ user })
+  })
+})
+
+describe('requireCronSecret', () => {
+  beforeEach(() => {
+    stubDenoEnv({ CRON_SECRET: 'top-secret' })
+  })
+
+  afterEach(() => {
+    delete (globalThis as { Deno?: DenoGlobal }).Deno
+  })
+
+  it('rejects a request without the secret', () => {
+    const result = requireCronSecret(makeRequest())
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(401)
+  })
+
+  it('rejects a wrong secret', () => {
+    const result = requireCronSecret(makeRequest({ Authorization: 'Bearer wrong' }))
+    expect((result as Response).status).toBe(401)
+  })
+
+  it('accepts the configured secret', () => {
+    const result = requireCronSecret(makeRequest({ Authorization: 'Bearer top-secret' }))
+    expect(result).toBeNull()
+  })
+
+  it('rejects everything when no secret is configured', () => {
+    stubDenoEnv({})
+    const result = requireCronSecret(makeRequest({ Authorization: 'Bearer top-secret' }))
+    expect((result as Response).status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Cosa cambia

Follow-up dai fix emersi dalla review del consolidamento 2026-07:

- **Welcome toast invito**: `authStore` emette un evento `window` oltre al flag, così il toast compare anche quando la dashboard è già montata (regressione dopo la rimozione del reload in B2). Nuovi `useWelcomeToast` + contratto `welcomeToast.ts`, con test.
- **FoodForm**: validazione runtime (Zod `.parse()`) di `storage_location`/`quantity_unit` dal DB invece di cast ciechi in modifica.
- **dataExport (GDPR)**: `joined_at` mancante resta `null` esplicito invece di `'N/A'`.
- **supabase.ts**: ripristinati i commenti-rationale rimossi fuori scope (auto-login di `detectSessionInUrl`, heartbeat 15s mobile).
- **Test Edge Functions**: unit test per `_shared/auth.ts` (`requireAuthenticatedUser` + `requireCronSecret`).
- **migrations/README**: regola "migration applicate = immutabili".
- **Release v1.10.0** (consolidamento + questi fix).

Doc private (gitignored, su disco): `docs/private/DATABASE_SCHEMA.md` riallineato allo schema reale.
Issue collegate: #67 (hardening GRANT anon/invites), correzioni a #60 e #64.

## Verifiche

- [x] `npm run lint` (solo warning Fast Refresh pre-esistenti)
- [x] `npm run typecheck`
- [x] `npm test` (248 test verdi)
- [x] `npm run build`

## Database e sicurezza

- [x] Nessuna modifica database
- [ ] Migration additive con RLS e GRANT espliciti
- [x] Autorizzazione e azioni distruttive coperte da test o smoke test

## UI/mobile

- [ ] Nessuna modifica UI
- [x] Verificata in viewport mobile
- [x] Testi e documentazione aggiornati se cambia il comportamento utente
