### PR TITLE
feat(security): harden invites access (#67) — NON deployare senza backup

### DIFF
--- a/src/lib/__tests__/invites.test.ts
+++ b/src/lib/__tests__/invites.test.ts
@@ -333,30 +333,19 @@ describe('acceptInviteWithConfirmation', () => {
 // ─── registerPendingInvite ─────────────────────────────────────────
 
 describe('registerPendingInvite', () => {
-  it('normalizes email (trim + lowercase)', async () => {
-    const updateMock = vi.fn().mockReturnValue({
-      eq: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      }),
-    })
-    mockFrom.mockReturnValue({ update: updateMock     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
+  it('calls the register_pending_invite RPC with normalized email (trim + lowercase)', async () => {
+    mockRpc.mockResolvedValue({ data: true, error: null })
 
     await registerPendingInvite('ABCDEF', ' User@TEST.com ')
 
-    expect(mockFrom).toHaveBeenCalledWith('invites')
-    expect(updateMock).toHaveBeenCalledWith({ pending_user_email: 'user@test.com' })
+    expect(mockRpc).toHaveBeenCalledWith('register_pending_invite', {
+      p_short_code: 'ABCDEF',
+      p_email: 'user@test.com',
+    })
   })
 
-  it('returns success when update succeeds', async () => {
-    mockFrom.mockReturnValue({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          eq: vi.fn().mockResolvedValue({ error: null }),
-        }),
-      }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
+  it('returns success when the RPC succeeds', async () => {
+    mockRpc.mockResolvedValue({ data: true, error: null })
 
     const result = await registerPendingInvite('ABCDEF', 'test@example.com')
 
@@ -364,16 +353,8 @@ describe('registerPendingInvite', () => {
     expect(result.error).toBeNull()
   })
 
-  it('returns error when supabase fails', async () => {
-    const supabaseError = { message: 'DB error', code: '42P01' }
-    mockFrom.mockReturnValue({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          eq: vi.fn().mockResolvedValue({ error: supabaseError }),
-        }),
-      }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
+  it('returns error when the RPC fails', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'permission denied', code: '42501' } })
 
     const result = await registerPendingInvite('ABCDEF', 'test@example.com')
 

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -103,12 +103,12 @@ export async function registerPendingInvite(
     // Normalize email to lowercase for consistent matching
     const normalizedEmail = userEmail.toLowerCase().trim()
 
-    // Update invite with pending user email
-    const { error } = await supabase
-      .from('invites')
-      .update({ pending_user_email: normalizedEmail })
-      .eq('short_code', shortCode.toUpperCase())
-      .eq('status', 'pending')
+    // Runs during signup as the anon role: go through a SECURITY DEFINER RPC so
+    // anon needs no direct grant/RLS access to the invites table (issue #67).
+    const { error } = await supabase.rpc('register_pending_invite', {
+      p_short_code: shortCode.toUpperCase(),
+      p_email: normalizedEmail,
+    })
 
     if (error) {
       console.error('[registerPendingInvite] Error registering pending invite:', error)

--- a/src/lib/supabase.types.ts
+++ b/src/lib/supabase.types.ts
@@ -367,6 +367,10 @@ export type Database = {
           list_id: string
         }[]
       }
+      register_pending_invite: {
+        Args: { p_email: string; p_short_code: string }
+        Returns: boolean
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20260706_harden_invites_access.sql
+++ b/supabase/migrations/20260706_harden_invites_access.sql
@@ -71,6 +71,13 @@ create policy "Authenticated can read pending or own-list invites"
 -- oppure modifica degli inviti delle proprie liste. WITH CHECK impedisce di
 -- lasciare l'invito in stato pending alterandone i campi (es. short_code) se
 -- non appartiene a una propria lista.
+--
+-- NB (invariante "join prima, accept dopo"): questa WITH CHECK NON impedisce a
+-- un non-membro di marcare accepted/expired un invito pending altrui (il ramo
+-- status ammette entrambi). L'ordine corretto dei flussi accept e' garantito
+-- dal CODICE, non da RLS: le UPDATE usano return=minimal (nessun RETURNING),
+-- quindi la SELECT policy non viene applicata alla riga nuova. Restringere il
+-- ramo status e' tracciato in #71 (non invertire l'ordine nel frattempo).
 create policy "Authenticated can update pending or own-list invites"
   on public.invites for update
   to authenticated

--- a/supabase/migrations/20260706_harden_invites_access.sql
+++ b/supabase/migrations/20260706_harden_invites_access.sql
@@ -1,0 +1,99 @@
+-- Hardening accesso a public.invites — issue #67
+--
+-- Problema: in produzione il ruolo `anon` aveva GRANT legacy ampi (retaggio
+-- pre Data API hardening) e due policy RLS `USING (true)` su `invites`. La
+-- combinazione permetteva a un client anonimo di leggere TUTTE le righe di
+-- invites (token, short_code, email) e di aggiornarle.
+--
+-- Questa migration e' ADDITIVA (nessun DROP di colonne/tabelle, nessuna
+-- perdita dati): sostituisce le policy permissive con versioni mirate, sposta
+-- l'unico accesso anonimo legittimo dietro una funzione SECURITY DEFINER, e
+-- revoca i privilegi legacy non necessari al ruolo `anon`.
+--
+-- Riferimenti: https://supabase.com/docs/guides/api/securing-your-api
+
+-- 1) Caso d'uso anonimo legittimo -------------------------------------------
+-- Durante il signup, prima della conferma email, il client (ancora anon)
+-- registra la propria email su un invito pending individuato dallo short_code.
+-- Con questa RPC l'anon non tocca piu' direttamente la tabella: la funzione
+-- gira come definer e aggiorna solo la colonna pending_user_email.
+create or replace function public.register_pending_invite(
+  p_short_code text,
+  p_email text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_updated integer;
+begin
+  if p_short_code is null or p_email is null then
+    return false;
+  end if;
+
+  update public.invites
+    set pending_user_email = lower(trim(p_email))
+  where short_code = upper(p_short_code)
+    and status = 'pending'
+    and expires_at > now();
+
+  get diagnostics v_updated = row_count;
+  return v_updated > 0;
+end;
+$$;
+
+comment on function public.register_pending_invite(text, text) is
+  'Registra pending_user_email su un invito pending individuato dallo short_code. Usata dal client anonimo durante il signup (issue #67), evita accesso diretto di anon alla tabella invites.';
+
+grant execute on function public.register_pending_invite(text, text)
+  to anon, authenticated, service_role;
+
+-- 2) Policy mirate al posto delle due USING(true) ---------------------------
+drop policy if exists "Public can read invites or list members can view their invites" on public.invites;
+drop policy if exists "System can update invite status" on public.invites;
+drop policy if exists "Authenticated can read pending or own-list invites" on public.invites;
+drop policy if exists "Authenticated can update pending or own-list invites" on public.invites;
+
+-- Lettura: solo utenti autenticati. Possono leggere gli inviti pending (per
+-- accettarli tramite short_code / pending_user_email) e quelli delle liste di
+-- cui sono membri. Il ruolo anon non legge piu' alcun invito.
+create policy "Authenticated can read pending or own-list invites"
+  on public.invites for select
+  to authenticated
+  using (
+    status = 'pending'
+    or list_id in (select public.get_user_list_ids())
+  );
+
+-- Aggiornamento: solo autenticati. Accettazione (pending -> accepted/expired)
+-- oppure modifica degli inviti delle proprie liste. WITH CHECK impedisce di
+-- lasciare l'invito in stato pending alterandone i campi (es. short_code) se
+-- non appartiene a una propria lista.
+create policy "Authenticated can update pending or own-list invites"
+  on public.invites for update
+  to authenticated
+  using (
+    status = 'pending'
+    or list_id in (select public.get_user_list_ids())
+  )
+  with check (
+    status in ('accepted', 'expired')
+    or list_id in (select public.get_user_list_ids())
+  );
+
+-- La policy "List members can create invites" (INSERT) resta invariata.
+
+-- 3) Grant minimi -----------------------------------------------------------
+-- anon non ha piu' alcun accesso diretto a invites: solo la RPC sopra.
+revoke all privileges on public.invites from anon;
+
+-- Difesa in profondita': revoca i privilegi legacy di scrittura di anon sulle
+-- tabelle utente (in produzione esistono per default pre-hardening; in locale
+-- sono per lo piu' no-op). Le policy RLS gia' negano le righe ad anon, ma il
+-- principio del minimo privilegio richiede di togliere anche i GRANT.
+revoke insert, update, delete, truncate, references on public.foods from anon;
+revoke insert, update, delete, truncate, references on public.lists from anon;
+revoke insert, update, delete, truncate, references on public.list_members from anon;
+revoke insert, update, delete, truncate, references on public.categories from anon;


### PR DESCRIPTION
Chiude l'esposizione preesistente su `public.invites` (issue #67): il ruolo `anon` poteva leggere e aggiornare **tutte** le righe (GRANT legacy + due policy `USING(true)`).

> ⚠️ **Non fondere/deployare senza backup produzione.** La migration è additiva ma cambia policy/grant su una tabella con dati reali. Prima del `supabase db push`: `supabase db dump` completo. La history migration remota è già stata riparata (2026-07-06).

## Cosa cambia

- **Nuova RPC** `register_pending_invite(short_code, email)` `SECURITY DEFINER`: l'unico accesso anonimo legittimo (registrazione email su invito pending durante il signup) passa da qui, così `anon` non tocca più direttamente la tabella. `registerPendingInvite()` chiama la RPC.
- **Policy mirate** al posto delle due `USING(true)`: SELECT/UPDATE `TO authenticated` (inviti pending o delle proprie liste). `anon` non legge più inviti.
- **Grant minimi**: `REVOKE ALL ON invites FROM anon` + revoca write legacy di `anon` su foods/lists/list_members/categories (difesa in profondità).

## Verifica su Supabase locale (`db reset` + simulazione ruoli)

- [x] anon SELECT/UPDATE diretti su `invites` → negati
- [x] `register_pending_invite` da anon → ok, email normalizzata
- [x] authenticated non-membro: vede invito pending → si unisce alla lista → marca `accepted` (flusso reale) → ok
- [x] authenticated non vede inviti `accepted` di liste altrui
- [x] anon senza write grant su foods/lists/list_members → negato
- [x] `npm run typecheck`, `npm run test:ci` (248), `npm run lint` (solo warning pre-esistenti)

## Nota di design (non-ovvia)

L'ordine dei flussi accept — prima inserire la membership in `list_members`, poi aggiornare l'invito ad `accepted` — è garantito dal **codice applicativo, non da RLS**. Le `.update()` non usano `.select()`, quindi PostgREST invia `return=minimal` → nessun `RETURNING` → la SELECT policy **non** viene applicata alla riga *nuova* ([doc Postgres CREATE POLICY](https://www.postgresql.org/docs/current/sql-createpolicy.html)). Di conseguenza la `WITH CHECK` da sola consentirebbe a un non-membro di marcare `accepted`/`expired` un invito `pending` altrui: restringere quel ramo è tracciato in #71. **Non invertire l'ordine** nel frattempo (`acceptInviteByEmail`, `acceptInviteWithConfirmation`).

## Residuo noto

Un utente autenticato può ancora leggere gli inviti `pending` (necessario per accettare per codice senza edge function). Chiusura completa = spostare anche i flussi accept dietro edge function/RPC. Fuori scope qui.

Spec completa (privata, gitignored): `docs/development/hardening-invites-spec.md`.
