### PR TITLE
fix(sharing): il menu inviti non sfora il viewport su mobile (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.10.2] - 2026-07-20
+
+### Fixed
+- Il menu **Inviti** non sfora più il bordo dello schermo su mobile: le descrizioni delle opzioni (racchiuse nei pulsanti) ora vanno a capo invece di essere troncate a destra. La causa era il `whitespace-nowrap` di default del componente `Button`, che impediva l'a-capo del testo lungo dentro il dialog a larghezza fissa. (#59)
+
 ## [1.10.1] - 2026-07-20
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
     env: {
       VITE_SUPABASE_URL: supabaseUrl,
       VITE_SUPABASE_ANON_KEY: supabaseAnonKey,
+      // Abilita l'UI di condivisione (menu inviti) per gli e2e che la esercitano.
+      VITE_ENABLE_SHARED_LISTS: 'true',
     },
   },
   projects: [

--- a/src/components/sharing/InviteMenuDialog.tsx
+++ b/src/components/sharing/InviteMenuDialog.tsx
@@ -45,7 +45,7 @@ export function InviteMenuDialog({
           {/* Option 1: Create invite */}
           <Button
             variant="outline"
-            className="h-auto flex-col items-start gap-2 p-4 text-left"
+            className="h-auto flex-col items-start gap-2 p-4 text-left whitespace-normal"
             onClick={() => handleOptionClick(onCreateInvite)}
           >
             <div className="flex items-center gap-3 w-full">
@@ -62,7 +62,7 @@ export function InviteMenuDialog({
           {/* Option 2: Accept invite */}
           <Button
             variant="outline"
-            className="h-auto flex-col items-start gap-2 p-4 text-left"
+            className="h-auto flex-col items-start gap-2 p-4 text-left whitespace-normal"
             onClick={() => handleOptionClick(onAcceptInvite)}
           >
             <div className="flex items-center gap-3 w-full">
@@ -80,7 +80,7 @@ export function InviteMenuDialog({
           {isInSharedList && (
             <Button
               variant="outline"
-              className="h-auto flex-col items-start gap-2 p-4 text-left border-destructive/50 hover:bg-destructive/10"
+              className="h-auto flex-col items-start gap-2 p-4 text-left whitespace-normal border-destructive/50 hover:bg-destructive/10"
               onClick={() => handleOptionClick(onLeaveList)}
             >
               <div className="flex items-center gap-3 w-full">

--- a/tests/e2e/helpers/supabase.ts
+++ b/tests/e2e/helpers/supabase.ts
@@ -58,3 +58,37 @@ export async function deleteE2EUserByEmail(email: string): Promise<void> {
     throw new Error(`Impossibile eliminare l'utente E2E ${email}: ${deleteError.message}`)
   }
 }
+
+/**
+ * Rende condivisa la lista personale dell'utente aggiungendo un secondo membro
+ * (via service-role, bypassando RLS). Così l'app rileva `isInSharedList` e il
+ * menu inviti mostra anche l'opzione "Abbandona lista condivisa".
+ * Ritorna il co-membro creato, da eliminare nel teardown.
+ */
+export async function makeUserListShared(userId: string, coMemberPassword: string): Promise<E2EUser> {
+  // L'app crea la lista personale al primo login (RPC `create_personal_list`,
+  // idempotente). La pre-creiamo qui così possiamo aggiungere subito un secondo
+  // membro; al login l'app troverà la membership esistente e non la duplicherà.
+  const { data: list, error: listError } = await adminClient
+    .from('lists')
+    .insert({ created_by: userId, name: 'Lista E2E condivisa' })
+    .select('id')
+    .single()
+
+  if (listError || !list) {
+    throw new Error(`Impossibile creare la lista E2E: ${listError?.message}`)
+  }
+
+  const coMember = await createE2EUser(createE2EEmail(), coMemberPassword)
+
+  const { error: membersError } = await adminClient.from('list_members').insert([
+    { list_id: list.id, user_id: userId },
+    { list_id: list.id, user_id: coMember.id },
+  ])
+
+  if (membersError) {
+    throw new Error(`Impossibile aggiungere i membri alla lista E2E: ${membersError.message}`)
+  }
+
+  return coMember
+}

--- a/tests/e2e/invite-menu-layout.spec.ts
+++ b/tests/e2e/invite-menu-layout.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+import {
+  createE2EEmail,
+  createE2EUser,
+  deleteE2EUserByEmail,
+  makeUserListShared,
+  type E2EUser,
+} from './helpers/supabase'
+
+const password = 'E2ePassword!2026'
+
+// Regressione #59 — "Broken mobile layout": su viewport mobile il dialog
+// "Inviti" sforava a destra perché le descrizioni dentro i <Button>
+// ereditavano `whitespace-nowrap` e non andavano a capo, spingendo il
+// contenuto oltre il bordo del viewport (testo troncato).
+test.use({ viewport: { width: 390, height: 844 } })
+
+test.describe('layout menu inviti (mobile)', () => {
+  let user: E2EUser
+  let coMember: E2EUser | undefined
+
+  test.beforeEach(async () => {
+    user = await createE2EUser(createE2EEmail(), password)
+    // Serve una lista condivisa per far comparire il bottone con la
+    // descrizione più lunga (quello troncato nello screenshot dell'issue).
+    coMember = await makeUserListShared(user.id, password)
+  })
+
+  test.afterEach(async () => {
+    await deleteE2EUserByEmail(user.email)
+    if (coMember) await deleteE2EUserByEmail(coMember.email)
+  })
+
+  test('il dialog "Inviti" non sfora il viewport orizzontalmente', async ({ page }, testInfo) => {
+    await page.goto('/login')
+    await page.getByLabel('Email').fill(user.email)
+    await page.locator('input[name="password"]').fill(password)
+    await page.getByRole('button', { name: 'Accedi' }).click()
+
+    await expect(page.getByRole('heading', { name: /Ciao, Utente E2E!/ })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Menu utente' }).click()
+    await page.getByRole('menuitem', { name: 'Inviti' }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Inviti' })
+    await expect(dialog).toBeVisible()
+    // Il bottone con la descrizione più lunga deve essere presente e per intero.
+    await expect(
+      dialog.getByText('Esci dalla lista condivisa e crea una nuova lista personale'),
+    ).toBeVisible()
+
+    await testInfo.attach('invite-menu-390px', {
+      body: await page.screenshot(),
+      contentType: 'image/png',
+    })
+
+    // Nessun elemento del dialog deve estendersi oltre il bordo destro del viewport.
+    const viewportWidth = page.viewportSize()!.width
+    const overflowing = await dialog.evaluate((root, vw) => {
+      const offenders: { text: string; right: number }[] = []
+      root.querySelectorAll('*').forEach((el) => {
+        const right = el.getBoundingClientRect().right
+        if (right > vw + 0.5) {
+          offenders.push({
+            text: (el.textContent ?? '').trim().slice(0, 40),
+            right: Math.round(right),
+          })
+        }
+      })
+      return offenders
+    }, viewportWidth)
+
+    expect(
+      overflowing,
+      `Elementi del dialog che sforano il viewport (${viewportWidth}px): ${JSON.stringify(overflowing)}`,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Chiude #59 ("Broken mobile layout").

## Cosa cambia

- **Fix**: nel dialog **Inviti** su mobile il pannello sforava a destra e il testo delle opzioni veniva troncato (es. *"…crea una nuova lista persona…"*). Causa: le descrizioni sono dentro `<Button>`, che ha `whitespace-nowrap` nella classe base → il testo lungo non andava a capo e superava la larghezza del dialog. Aggiunto `whitespace-normal` ai tre bottoni del menu; il componente `Button` globale non è toccato.
- **Test**: nuovo e2e Playwright (`tests/e2e/invite-menu-layout.spec.ts`, viewport 390px, lista condivisa seedata) che asserisce che nessun elemento del dialog superi il bordo destro del viewport (verificato RED→GREEN). Helper `makeUserListShared`; `VITE_ENABLE_SHARED_LISTS=true` nel webServer e2e (senza flag il menu inviti non è renderizzato).
- **CHANGELOG** + bump a `1.10.2`.

## Verifiche

- [x] `npm run lint` (0 errori, warning pre-esistenti)
- [x] `npm run typecheck`
- [x] `npm test` (248)
- [x] `npm run build`

## Database e sicurezza

- [x] Nessuna modifica database
- [ ] Migration additive con RLS e GRANT espliciti
- [ ] Autorizzazione e azioni distruttive coperte da test o smoke test

## UI/mobile

- [ ] Nessuna modifica UI
- [x] Verificata in viewport mobile (Playwright 390px + screenshot; descrizioni ora a capo, dialog contenuto)
- [x] Testi e documentazione aggiornati se cambia il comportamento utente (CHANGELOG)