### PR TITLE
fix(deps): bump undici 7.24.7 → 7.28.0 (Dependabot security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11384,9 +11384,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Risolve le 6 segnalazioni Dependabot aperte, tutte sullo stesso pacchetto **`undici`** (patchate in `7.28.0`).

## Cosa cambia

- Bump della dipendenza transitiva `undici` `7.24.7 → 7.28.0` (solo `package-lock.json`).
- `undici` è tirata da `jsdom@29.0.1` (**devDependency**, ambiente jsdom dei test vitest) → **non è nel bundle di produzione**, nessun impatto sull'app deployata. Il range di jsdom (`^7.24.5`) ammette già 7.28.0, quindi nessuna modifica a `package.json`.

## Advisory risolte

| Sev | GHSA | Descrizione |
|---|---|---|
| High | GHSA-vmh5-mc38-953g | TLS cert validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| High | GHSA-hm92-r4w5-c3mj | cross-origin request routing via SOCKS5 proxy pool reuse |
| Medium | GHSA-p88m-4jfj-68fv | HTTP header injection via Set-Cookie percent-decoding |
| Medium | GHSA-pr7r-676h-xcf6 | cross-user info disclosure via shared cache whitespace bypass |
| Low | GHSA-g8m3-5g58-fq7m | Set-Cookie SameSite downgrade via permissive substring matching |
| Low | GHSA-35p6-xmwp-9g52 | HTTP response queue poisoning via keep-alive socket reuse |

## Verifiche

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (248)
- [x] `npm run build`

## Database e sicurezza

- [x] Nessuna modifica database
- [ ] Migration additive con RLS e GRANT espliciti
- [ ] Autorizzazione e azioni distruttive coperte da test o smoke test

## UI/mobile

- [x] Nessuna modifica UI
- [ ] Verificata in viewport mobile
- [ ] Testi e documentazione aggiornati se cambia il comportamento utente