### PR TITLE
feat(security): membership solo via invito valido — RPC join + hardening RLS (#70, #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.10.3] - 2026-07-20
+
+### Security
+- La membership a una lista è ora ottenibile solo tramite un invito valido, mediata da RPC `SECURITY DEFINER`: rimosso l'INSERT diretto client su `list_members` (un utente autenticato non può più auto-aggiungersi a liste altrui) e ristretta la lettura degli inviti (niente più harvest di `short_code` altrui). (#70, #71)
+
 ## [1.10.2] - 2026-07-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.10.2",
+  "version": "1.10.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/__tests__/invites.test.ts
+++ b/src/lib/__tests__/invites.test.ts
@@ -68,265 +68,38 @@ beforeEach(() => {
 // ─── acceptInviteByEmail ───────────────────────────────────────────
 
 describe('acceptInviteByEmail', () => {
-  it('returns failure when user is not authenticated', async () => {
-    mockAuth.getUser.mockResolvedValue({ data: { user: null } })
-
+  it('chiama la RPC accept_pending_invite_by_email e mappa il successo', async () => {
+    mockRpc.mockResolvedValue({ data: [{ list_id: 'list-1', success: true, error_message: null }], error: null })
     const result = await acceptInviteByEmail()
-
-    expect(result.success).toBe(false)
+    expect(mockRpc).toHaveBeenCalledWith('accept_pending_invite_by_email')
+    expect(result).toEqual({ success: true, listId: 'list-1', error: null })
   })
 
-  it('returns failure when user has no email', async () => {
-    mockAuth.getUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: null } },
-    })
-
+  it('ritorna no-op quando non c\'è invito', async () => {
+    mockRpc.mockResolvedValue({ data: [{ list_id: null, success: false, error_message: null }], error: null })
     const result = await acceptInviteByEmail()
-
     expect(result.success).toBe(false)
+    expect(result.listId).toBeNull()
     expect(result.error).toBeNull()
-  })
-
-  it('returns failure with no error when no pending invite found', async () => {
-    mockAuth.getUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'test@example.com' } },
-    })
-    mockBuilder.maybeSingle.mockResolvedValue({ data: null, error: null })
-
-    const result = await acceptInviteByEmail()
-
-    expect(result.success).toBe(false)
-    expect(result.error).toBeNull()
-  })
-
-  it('marks invite as expired when expires_at is in the past', async () => {
-    mockAuth.getUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'test@example.com' } },
-    })
-
-    const expiredInvite = {
-      id: 'inv1',
-      list_id: 'list1',
-      expires_at: '2020-01-01T00:00:00Z',
-      status: 'pending',
-      pending_user_email: 'test@example.com',
-    }
-
-    mockBuilder.maybeSingle.mockResolvedValueOnce({ data: expiredInvite, error: null })
-
-    const result = await acceptInviteByEmail()
-
-    expect(result.success).toBe(false)
-    expect(result.error).toBeTruthy()
-    expect(mockFrom).toHaveBeenCalledWith('invites')
-    expect(mockBuilder.update).toHaveBeenCalledWith({ status: 'expired' })
-  })
-
-  it('marks invite as accepted when user is already a member', async () => {
-    mockAuth.getUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'test@example.com' } },
-    })
-
-    const validInvite = {
-      id: 'inv1',
-      list_id: 'list1',
-      expires_at: '2030-01-01T00:00:00Z',
-      status: 'pending',
-      pending_user_email: 'test@example.com',
-    }
-
-    mockBuilder.maybeSingle
-      .mockResolvedValueOnce({ data: validInvite, error: null })
-      .mockResolvedValueOnce({ data: { list_id: 'list1', user_id: 'u1' }, error: null })
-
-    const result = await acceptInviteByEmail()
-
-    expect(result.success).toBe(true)
-    expect(result.listId).toBe('list1')
-    expect(mockBuilder.update).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'accepted' })
-    )
-  })
-
-  it('happy path: inserts member and accepts invite', async () => {
-    mockAuth.getUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'test@example.com' } },
-    })
-
-    const validInvite = {
-      id: 'inv1',
-      list_id: 'list1',
-      expires_at: '2030-01-01T00:00:00Z',
-      status: 'pending',
-      pending_user_email: 'test@example.com',
-    }
-
-    mockBuilder.maybeSingle
-      .mockResolvedValueOnce({ data: validInvite, error: null })
-      .mockResolvedValueOnce({ data: null, error: null })
-
-    mockBuilder.insert.mockReturnValue({ error: null })
-
-    const result = await acceptInviteByEmail()
-
-    expect(result.success).toBe(true)
-    expect(result.listId).toBe('list1')
-    expect(mockBuilder.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ list_id: 'list1', user_id: 'u1' })
-    )
-  })
-
-  it('uses ilike for case-insensitive email matching', async () => {
-    mockAuth.getUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'User@Test.COM' } },
-    })
-    mockBuilder.maybeSingle.mockResolvedValue({ data: null, error: null })
-
-    await acceptInviteByEmail()
-
-    expect(mockBuilder.ilike).toHaveBeenCalledWith('pending_user_email', 'user@test.com')
   })
 })
 
 // ─── acceptInviteWithConfirmation ──────────────────────────────────
 
 describe('acceptInviteWithConfirmation', () => {
-  beforeEach(() => {
-    mockAuth.getUser.mockResolvedValue({
-      data: { user: { id: 'u1' } },
-    })
+  it('chiama join_list_via_invite e propaga requires_confirmation + foodCount', async () => {
+    mockRpc.mockResolvedValue({ data: [{ list_id: null, success: false, requires_confirmation: true, food_count: 3, error_message: null }], error: null })
+    const result = await acceptInviteWithConfirmation('abc123')
+    expect(mockRpc).toHaveBeenCalledWith('join_list_via_invite', { p_short_code: 'ABC123', p_force: false })
+    expect(result.requiresConfirmation).toBe(true)
+    expect(result.foodCount).toBe(3)
   })
 
-  it('returns error when invite is not found', async () => {
-    mockBuilder.maybeSingle.mockResolvedValue({ data: null, error: null })
-
-    const result = await acceptInviteWithConfirmation('ABCDEF')
-
-    expect(result.success).toBe(false)
-    expect(result.error).toBeTruthy()
-  })
-
-  it('marks invite expired and returns error when expired', async () => {
-    const expiredInvite = {
-      id: 'inv1',
-      list_id: 'list1',
-      short_code: 'ABCDEF',
-      expires_at: '2020-01-01T00:00:00Z',
-      status: 'pending',
-    }
-    mockBuilder.maybeSingle.mockResolvedValueOnce({ data: expiredInvite, error: null })
-
-    const result = await acceptInviteWithConfirmation('ABCDEF')
-
-    expect(result.success).toBe(false)
-    expect(mockBuilder.update).toHaveBeenCalledWith({ status: 'expired' })
-  })
-
-  it('adds user directly when user has no list', async () => {
-    const invite = {
-      id: 'inv1',
-      list_id: 'list1',
-      short_code: 'ABCDEF',
-      expires_at: '2030-01-01T00:00:00Z',
-      status: 'pending',
-    }
-
-    mockBuilder.maybeSingle
-      .mockResolvedValueOnce({ data: invite, error: null })
-      .mockResolvedValueOnce({ data: null, error: null })
-
-    mockBuilder.insert.mockReturnValue({ error: null })
-
-    const result = await acceptInviteWithConfirmation('ABCDEF')
-
-    expect(result.success).toBe(true)
-    expect(result.listId).toBe('list1')
-  })
-
-  it('is idempotent when user is already in the same list', async () => {
-    const invite = {
-      id: 'inv1',
-      list_id: 'list1',
-      short_code: 'ABCDEF',
-      expires_at: '2030-01-01T00:00:00Z',
-      status: 'pending',
-    }
-
-    mockBuilder.maybeSingle
-      .mockResolvedValueOnce({ data: invite, error: null })
-      .mockResolvedValueOnce({ data: { list_id: 'list1' }, error: null })
-
-    const result = await acceptInviteWithConfirmation('ABCDEF')
-
-    expect(result.success).toBe(true)
-    expect(result.listId).toBe('list1')
-    expect(mockBuilder.insert).not.toHaveBeenCalled()
-  })
-
-  it('forceAccept: removes from old list and adds to new', async () => {
-    const invite = {
-      id: 'inv1',
-      list_id: 'new-list',
-      short_code: 'ABCDEF',
-      expires_at: '2030-01-01T00:00:00Z',
-      status: 'pending',
-    }
-
-    mockBuilder.maybeSingle
-      .mockResolvedValueOnce({ data: invite, error: null })
-      .mockResolvedValueOnce({ data: { list_id: 'old-list' }, error: null })
-
-    // After the two maybeSingle calls, the function does many from() calls.
-    // We use mockImplementation to return different builders per call.
-    let fromCallCount = 0
-    mockFrom.mockImplementation((() => {
-      fromCallCount++
-      if (fromCallCount <= 2) return mockBuilder // first 2 use maybeSingle
-      if (fromCallCount === 3) {
-        // foods count
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ count: 5, error: null }),
-          }),
-        }
-      }
-      if (fromCallCount === 4) {
-        // delete from list_members
-        return {
-          delete: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockResolvedValue({ error: null }),
-            }),
-          }),
-        }
-      }
-      if (fromCallCount === 5) {
-        // count remaining members
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ count: 2, error: null }),
-          }),
-        }
-      }
-      if (fromCallCount === 6) {
-        // insert new member
-        return {
-          insert: vi.fn().mockResolvedValue({ error: null }),
-        }
-      }
-      // update invite status
-      return {
-        update: vi.fn().mockReturnValue({
-          eq: vi.fn().mockResolvedValue({ error: null }),
-        }),
-      }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any)
-
-    const result = await acceptInviteWithConfirmation('ABCDEF', true)
-
-    expect(result.success).toBe(true)
-    expect(result.listId).toBe('new-list')
+  it('mappa il successo con list_id', async () => {
+    mockRpc.mockResolvedValue({ data: [{ list_id: 'list-9', success: true, requires_confirmation: false, food_count: null, error_message: null }], error: null })
+    const result = await acceptInviteWithConfirmation('abc123', true)
+    expect(mockRpc).toHaveBeenCalledWith('join_list_via_invite', { p_short_code: 'ABC123', p_force: true })
+    expect(result).toMatchObject({ success: true, listId: 'list-9', requiresConfirmation: false })
   })
 })
 

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -170,155 +170,24 @@ export async function acceptInvite(shortCode: string): Promise<AcceptInviteRespo
 /**
  * Accepts a pending invite by the authenticated user's email
  * Used when user confirms email after signup with invite
- * Direct database implementation to bypass Edge Function JWT issues
+ * Runs server-side via SECURITY DEFINER RPC (issue #70/#71) so the client
+ * needs no direct table access to `invites`/`list_members`.
  * @returns Response with success status and list ID
  */
 export async function acceptInviteByEmail(): Promise<AcceptInviteResponse> {
   try {
-    // Get current user
-    const { data: userData } = await supabase.auth.getUser()
-    if (!userData.user) {
-      console.error('[acceptInviteByEmail] User not authenticated')
-      throw new Error('Not authenticated')
+    const { data, error } = await supabase.rpc('accept_pending_invite_by_email')
+    if (error) {
+      console.error('[acceptInviteByEmail] RPC error:', error)
+      return { success: false, listId: null, error: new Error(error.message) }
     }
-
-    const userId = userData.user.id
-    const userEmail = userData.user.email
-
-    // Check if user has an email
-    if (!userEmail) {
-      console.warn('[acceptInviteByEmail] User has no email address')
-      return {
-        success: false,
-        listId: null,
-        error: null,
-      }
+    const row = Array.isArray(data) ? data[0] : data
+    if (!row || !row.success) {
+      return { success: false, listId: null, error: row?.error_message ? new Error(row.error_message) : null }
     }
-
-    // Normalize email for matching
-    const normalizedEmail = userEmail.toLowerCase().trim()
-
-    // Find pending invite for this email (using pending_user_email field)
-    // Use ilike for case-insensitive email matching
-    const { data: inviteData, error: inviteError } = await supabase
-      .from('invites')
-      .select('*')
-      .ilike('pending_user_email', normalizedEmail)
-      .eq('status', 'pending')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle()
-
-    if (inviteError) {
-      console.error('[acceptInviteByEmail] Error querying invites:', inviteError)
-      throw inviteError
-    }
-
-    if (!inviteData) {
-      return {
-        success: false,
-        listId: null,
-        error: null, // Not an error, just no invite
-      }
-    }
-
-    // Check if invite has expired
-    const expiresAt = new Date(inviteData.expires_at)
-    const now = new Date()
-
-    if (expiresAt < now) {
-      console.warn('[acceptInviteByEmail] Invite has expired:', {
-        expiresAt: expiresAt.toISOString(),
-        now: now.toISOString(),
-      })
-
-      // Update invite status to expired
-      await supabase
-        .from('invites')
-        .update({ status: 'expired' })
-        .eq('id', inviteData.id)
-
-      return {
-        success: false,
-        listId: null,
-        error: new Error('This invite has expired'),
-      }
-    }
-
-    // Check if user is already a member of this list
-    const { data: existingMember, error: memberCheckError } = await supabase
-      .from('list_members')
-      .select('*')
-      .eq('list_id', inviteData.list_id)
-      .eq('user_id', userId)
-      .maybeSingle()
-
-    if (memberCheckError) {
-      console.error('[acceptInviteByEmail] Error checking existing membership:', memberCheckError)
-    }
-
-    if (existingMember) {
-      // User is already a member, just mark invite as accepted
-      await supabase
-        .from('invites')
-        .update({
-          status: 'accepted',
-          accepted_at: new Date().toISOString(),
-        })
-        .eq('id', inviteData.id)
-
-      return {
-        success: true,
-        listId: inviteData.list_id,
-        error: null,
-      }
-    }
-
-    // Add user to list_members
-    const { error: memberError } = await supabase
-      .from('list_members')
-      .insert({
-        list_id: inviteData.list_id,
-        user_id: userId,
-      })
-
-    if (memberError) {
-      console.error('[acceptInviteByEmail] Error adding member to list:', {
-        error: memberError,
-        code: memberError.code,
-        message: memberError.message,
-        details: memberError.details,
-        hint: memberError.hint,
-      })
-      throw memberError
-    }
-
-    // Update invite status to accepted
-    const { error: updateError } = await supabase
-      .from('invites')
-      .update({
-        status: 'accepted',
-        accepted_at: new Date().toISOString(),
-      })
-      .eq('id', inviteData.id)
-
-    if (updateError) {
-      console.error('[acceptInviteByEmail] Error updating invite status:', updateError)
-      // Don't fail if we can't update the status - the member was added successfully
-    }
-
-    return {
-      success: true,
-      listId: inviteData.list_id,
-      error: null,
-    }
+    return { success: true, listId: row.list_id, error: null }
   } catch (error) {
-    console.error('[acceptInviteByEmail] Failed to accept invite by email:', error)
-    return {
-      success: false,
-      listId: null,
-      error: error instanceof Error ? error : new Error('Unknown error'),
-    }
+    return { success: false, listId: null, error: error instanceof Error ? error : new Error('Unknown error') }
   }
 }
 
@@ -479,6 +348,8 @@ export async function createPersonalList(): Promise<{
  * Accepts an invite with confirmation logic for "Single List" approach
  * If user has an existing list, returns requiresConfirmation=true with food count
  * If forceAccept=true, removes user from old list and adds to new one
+ * Runs server-side via SECURITY DEFINER RPC (issue #70/#71) so the client
+ * needs no direct table access to `invites`/`list_members`/`lists`/`foods`.
  * @param shortCode - The invite short code
  * @param forceAccept - If true, bypasses confirmation and accepts invite
  * @returns Response with confirmation requirement or success
@@ -488,197 +359,26 @@ export async function acceptInviteWithConfirmation(
   forceAccept: boolean = false
 ): Promise<AcceptInviteConfirmationResponse> {
   try {
-    const { data: userData } = await supabase.auth.getUser()
-    if (!userData.user) {
-      throw new Error('Not authenticated')
+    const { data, error } = await supabase.rpc('join_list_via_invite', {
+      p_short_code: shortCode.toUpperCase(),
+      p_force: forceAccept,
+    })
+    if (error) {
+      return { success: false, listId: null, requiresConfirmation: false, error: new Error(error.message) }
     }
-
-    const userId = userData.user.id
-    const upperShortCode = shortCode.toUpperCase()
-
-    // Step 1: Validate invite
-    const { data: inviteData, error: inviteError } = await supabase
-      .from('invites')
-      .select('*')
-      .eq('short_code', upperShortCode)
-      .eq('status', 'pending')
-      .maybeSingle()
-
-    if (inviteError) {
-      throw inviteError
+    const row = Array.isArray(data) ? data[0] : data
+    if (!row) {
+      return { success: false, listId: null, requiresConfirmation: false, error: new Error('Nessuna risposta') }
     }
-
-    if (!inviteData) {
-      throw new Error('Invito non valido o scaduto')
+    if (row.requires_confirmation) {
+      return { success: false, listId: null, requiresConfirmation: true, foodCount: row.food_count ?? 0, error: null }
     }
-
-    // Check if invite has expired
-    const expiresAt = new Date(inviteData.expires_at)
-    const now = new Date()
-
-    if (expiresAt < now) {
-      // Update invite status to expired
-      await supabase
-        .from('invites')
-        .update({ status: 'expired' })
-        .eq('id', inviteData.id)
-
-      throw new Error('Questo invito è scaduto')
+    if (!row.success) {
+      return { success: false, listId: null, requiresConfirmation: false, error: row.error_message ? new Error(row.error_message) : new Error('Accettazione non riuscita') }
     }
-
-    // Step 2: Check if user already has a list
-    const { data: currentMemberData, error: currentMemberError } = await supabase
-      .from('list_members')
-      .select('list_id')
-      .eq('user_id', userId)
-      .maybeSingle()
-
-    if (currentMemberError) {
-      throw currentMemberError
-    }
-
-    // Step 3: If user has no list, just add them to the new list
-    if (!currentMemberData) {
-      // Add user to new list
-      const { error: memberError } = await supabase
-        .from('list_members')
-        .insert({
-          list_id: inviteData.list_id,
-          user_id: userId,
-        })
-
-      if (memberError) {
-        throw memberError
-      }
-
-      // Update invite status to accepted
-      await supabase
-        .from('invites')
-        .update({
-          status: 'accepted',
-          accepted_at: new Date().toISOString(),
-        })
-        .eq('id', inviteData.id)
-
-      return {
-        success: true,
-        listId: inviteData.list_id,
-        requiresConfirmation: false,
-        error: null,
-      }
-    }
-
-    // Step 4: User has a list - check if it's the same list
-    if (currentMemberData.list_id === inviteData.list_id) {
-      // User is already in this list
-      await supabase
-        .from('invites')
-        .update({
-          status: 'accepted',
-          accepted_at: new Date().toISOString(),
-        })
-        .eq('id', inviteData.id)
-
-      return {
-        success: true,
-        listId: inviteData.list_id,
-        requiresConfirmation: false,
-        error: null,
-      }
-    }
-
-    // Step 5: User has a different list - get food count
-    const { count: foodCount, error: foodCountError } = await supabase
-      .from('foods')
-      .select('*', { count: 'exact', head: true })
-      .eq('list_id', currentMemberData.list_id)
-
-    if (foodCountError) {
-      throw foodCountError
-    }
-
-    // Step 6: If not forcing, return confirmation required
-    if (!forceAccept) {
-      return {
-        success: false,
-        listId: null,
-        requiresConfirmation: true,
-        foodCount: foodCount || 0,
-        error: null,
-      }
-    }
-
-    // Step 7: Force accept - remove from old list and add to new one
-    const oldListId = currentMemberData.list_id
-
-    // Remove user from old list
-    const { error: removeError } = await supabase
-      .from('list_members')
-      .delete()
-      .eq('list_id', oldListId)
-      .eq('user_id', userId)
-
-    if (removeError) {
-      throw removeError
-    }
-
-    // Check if old list has any members left
-    const { count: remainingMembers, error: membersCountError } = await supabase
-      .from('list_members')
-      .select('*', { count: 'exact', head: true })
-      .eq('list_id', oldListId)
-
-    if (membersCountError) {
-      throw membersCountError
-    }
-
-    // If old list has no members, delete it (CASCADE will delete foods)
-    if (remainingMembers === 0) {
-      const { error: deleteError } = await supabase
-        .from('lists')
-        .delete()
-        .eq('id', oldListId)
-
-      if (deleteError) {
-        console.error('Error deleting old list:', deleteError)
-        // Don't fail the whole operation if delete fails
-      }
-    }
-
-    // Add user to new list
-    const { error: newMemberError } = await supabase
-      .from('list_members')
-      .insert({
-        list_id: inviteData.list_id,
-        user_id: userId,
-      })
-
-    if (newMemberError) {
-      throw newMemberError
-    }
-
-    // Update invite status to accepted
-    await supabase
-      .from('invites')
-      .update({
-        status: 'accepted',
-        accepted_at: new Date().toISOString(),
-      })
-      .eq('id', inviteData.id)
-
-    return {
-      success: true,
-      listId: inviteData.list_id,
-      requiresConfirmation: false,
-      error: null,
-    }
+    return { success: true, listId: row.list_id, requiresConfirmation: false, error: null }
   } catch (error) {
-    return {
-      success: false,
-      listId: null,
-      requiresConfirmation: false,
-      error: error instanceof Error ? error : new Error('Unknown error'),
-    }
+    return { success: false, listId: null, requiresConfirmation: false, error: error instanceof Error ? error : new Error('Unknown error') }
   }
 }
 

--- a/src/lib/supabase.types.ts
+++ b/src/lib/supabase.types.ts
@@ -334,6 +334,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      accept_pending_invite_by_email: {
+        Args: Record<string, never>
+        Returns: {
+          error_message: string
+          list_id: string
+          success: boolean
+        }[]
+      }
       create_personal_list: {
         Args: never
         Returns: {
@@ -341,6 +349,10 @@ export type Database = {
           list_id: string
           success: boolean
         }[]
+      }
+      current_user_email: {
+        Args: Record<string, never>
+        Returns: string
       }
       delete_user: { Args: never; Returns: undefined }
       get_expiring_foods_for_notifications: {
@@ -365,6 +377,16 @@ export type Database = {
         Args: never
         Returns: {
           list_id: string
+        }[]
+      }
+      join_list_via_invite: {
+        Args: { p_force?: boolean; p_short_code: string }
+        Returns: {
+          error_message: string
+          food_count: number
+          list_id: string
+          requires_confirmation: boolean
+          success: boolean
         }[]
       }
       register_pending_invite: {

--- a/supabase/migrations/20260720_harden_list_members_join.sql
+++ b/supabase/migrations/20260720_harden_list_members_join.sql
@@ -138,3 +138,24 @@ end;
 $$;
 
 grant execute on function public.join_list_via_invite(text, boolean) to authenticated, service_role;
+
+-- 4) Write hardening: niente insert diretto client su list_members
+drop policy if exists "Users can add themselves to a list via invite" on public.list_members;
+revoke insert on public.list_members from authenticated;
+-- Restano: SELECT (proprie liste) e DELETE (auth.uid()=user_id, self-leave).
+-- create_personal_list e le RPC sopra (SECURITY DEFINER) + edge accept-invite
+-- (service_role) continuano a funzionare.
+
+-- 5) Read hardening: niente harvest di short_code/inviti altrui
+drop policy if exists "Authenticated can read pending or own-list invites" on public.invites;
+create policy "Authenticated can read own-list or own-email invites"
+  on public.invites for select
+  to authenticated
+  using (
+    list_id in (select public.get_user_list_ids())
+    or lower(pending_user_email) = lower(public.current_user_email())
+  );
+
+-- L'accept passa dalle RPC: il client non aggiorna più invites.
+drop policy if exists "Authenticated can update pending or own-list invites" on public.invites;
+revoke update on public.invites from authenticated;

--- a/supabase/migrations/20260720_harden_list_members_join.sql
+++ b/supabase/migrations/20260720_harden_list_members_join.sql
@@ -63,3 +63,78 @@ end;
 $$;
 
 grant execute on function public.accept_pending_invite_by_email() to authenticated, service_role;
+
+-- 3) RPC: accept per codice con logica single-list (conferma/food_count/force-swap)
+create or replace function public.join_list_via_invite(
+  p_short_code text,
+  p_force boolean default false
+)
+returns table (list_id uuid, success boolean, requires_confirmation boolean, food_count integer, error_message text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_invite public.invites%rowtype;
+  v_current_list_id uuid;
+  v_food_count integer;
+  v_remaining integer;
+begin
+  if v_user_id is null then
+    return query select null::uuid, false, false, null::integer, 'User not authenticated'::text; return;
+  end if;
+  if p_short_code is null or length(trim(p_short_code)) = 0 then
+    return query select null::uuid, false, false, null::integer, 'Invito non valido'::text; return;
+  end if;
+
+  select i.* into v_invite
+  from public.invites i
+  where i.short_code = upper(p_short_code) and i.status = 'pending';
+
+  if v_invite.id is null then
+    return query select null::uuid, false, false, null::integer, 'Invito non valido o scaduto'::text; return;
+  end if;
+
+  if v_invite.expires_at <= now() then
+    update public.invites set status = 'expired' where id = v_invite.id;
+    return query select null::uuid, false, false, null::integer, 'Questo invito è scaduto'::text; return;
+  end if;
+
+  select lm.list_id into v_current_list_id
+  from public.list_members lm
+  where lm.user_id = v_user_id
+  limit 1;
+
+  -- già membro della lista dell'invito
+  if v_current_list_id is not null and v_current_list_id = v_invite.list_id then
+    update public.invites set status = 'accepted', accepted_at = now() where id = v_invite.id;
+    return query select v_invite.list_id, true, false, null::integer, null::text; return;
+  end if;
+
+  -- nessuna lista precedente → join diretto
+  if v_current_list_id is null then
+    insert into public.list_members (list_id, user_id) values (v_invite.list_id, v_user_id);
+    update public.invites set status = 'accepted', accepted_at = now() where id = v_invite.id;
+    return query select v_invite.list_id, true, false, null::integer, null::text; return;
+  end if;
+
+  -- ha un'altra lista → conferma se non forzato
+  if not p_force then
+    select count(*)::integer into v_food_count from public.foods f where f.list_id = v_current_list_id;
+    return query select null::uuid, false, true, v_food_count, null::text; return;
+  end if;
+
+  -- force: rimuovi dalla vecchia, cancella se vuota (foods in cascade), aggiungi alla nuova
+  delete from public.list_members lm where lm.list_id = v_current_list_id and lm.user_id = v_user_id;
+  select count(*)::integer into v_remaining from public.list_members lm where lm.list_id = v_current_list_id;
+  if v_remaining = 0 then
+    delete from public.lists l where l.id = v_current_list_id;
+  end if;
+  insert into public.list_members (list_id, user_id) values (v_invite.list_id, v_user_id);
+  update public.invites set status = 'accepted', accepted_at = now() where id = v_invite.id;
+  return query select v_invite.list_id, true, false, null::integer, null::text;
+end;
+$$;
+
+grant execute on function public.join_list_via_invite(text, boolean) to authenticated, service_role;

--- a/supabase/migrations/20260720_harden_list_members_join.sql
+++ b/supabase/migrations/20260720_harden_list_members_join.sql
@@ -1,0 +1,65 @@
+-- Hardening join list_members — issue #70 (+ #71)
+-- Membership solo via invito valido, mediata da RPC SECURITY DEFINER.
+-- Riferimenti: https://supabase.com/docs/guides/database/functions
+--              https://supabase.com/docs/guides/database/postgres/row-level-security
+
+-- 1) Helper: email autoritativa del caller (da auth.users, non dal JWT)
+create or replace function public.current_user_email()
+returns text
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select u.email from auth.users u where u.id = auth.uid();
+$$;
+
+grant execute on function public.current_user_email() to authenticated, service_role;
+
+-- 2) RPC: auto-accept dell'invito pending indirizzato alla propria email
+create or replace function public.accept_pending_invite_by_email()
+returns table (list_id uuid, success boolean, error_message text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_email text;
+  v_invite public.invites%rowtype;
+  v_is_member boolean;
+begin
+  if v_user_id is null then
+    return query select null::uuid, false, 'User not authenticated'::text; return;
+  end if;
+
+  select u.email into v_email from auth.users u where u.id = v_user_id;
+
+  select i.* into v_invite
+  from public.invites i
+  where lower(i.pending_user_email) = lower(v_email)
+    and i.status = 'pending'
+    and i.expires_at > now()
+  order by i.created_at desc
+  limit 1;
+
+  if v_invite.id is null then
+    return query select null::uuid, false, null::text; return; -- no-op
+  end if;
+
+  select exists (
+    select 1 from public.list_members lm
+    where lm.list_id = v_invite.list_id and lm.user_id = v_user_id
+  ) into v_is_member;
+
+  if not v_is_member then
+    insert into public.list_members (list_id, user_id) values (v_invite.list_id, v_user_id);
+  end if;
+
+  update public.invites set status = 'accepted', accepted_at = now() where id = v_invite.id;
+
+  return query select v_invite.list_id, true, null::text;
+end;
+$$;
+
+grant execute on function public.accept_pending_invite_by_email() to authenticated, service_role;

--- a/tests/e2e/helpers/supabase.ts
+++ b/tests/e2e/helpers/supabase.ts
@@ -97,6 +97,34 @@ export async function makeUserListShared(userId: string, coMemberPassword: strin
 }
 
 /**
+ * Crea una lista per `ownerId` e un invito pending indirizzato a `inviteeEmail`.
+ * Ritorna il list_id. Usa il service-role (bypassa RLS).
+ */
+export async function seedPendingInviteByEmail(ownerId: string, inviteeEmail: string): Promise<string> {
+  const { data: list, error: listError } = await adminClient
+    .from('lists')
+    .insert({ created_by: ownerId, name: 'Lista invito E2E' })
+    .select('id')
+    .single()
+  if (listError || !list) throw new Error(`Impossibile creare la lista invito: ${listError?.message}`)
+
+  await adminClient.from('list_members').insert({ list_id: list.id, user_id: ownerId })
+
+  const { error: inviteError } = await adminClient.from('invites').insert({
+    list_id: list.id,
+    email: inviteeEmail,
+    pending_user_email: inviteeEmail.toLowerCase(),
+    token: `e2e-${crypto.randomUUID()}`,
+    short_code: crypto.randomUUID().slice(0, 8).toUpperCase(),
+    created_by: ownerId,
+    status: 'pending',
+    expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+  })
+  if (inviteError) throw new Error(`Impossibile creare l'invito: ${inviteError.message}`)
+  return list.id
+}
+
+/**
  * Client anonimo (ruolo `anon`), senza persistenza di sessione: usato come
  * base per l'autenticazione via password nei test e2e.
  */

--- a/tests/e2e/helpers/supabase.ts
+++ b/tests/e2e/helpers/supabase.ts
@@ -148,8 +148,14 @@ export async function signInAsUser(email: string, password: string): Promise<Sup
   return client
 }
 
-/** Crea una lista con owner e un invito pending con short_code noto. Ritorna { listId, shortCode }. */
-export async function seedPendingInviteByCode(ownerId: string): Promise<{ listId: string; shortCode: string }> {
+/**
+ * Crea una lista con owner e un invito pending con short_code noto. Ritorna { listId, shortCode }.
+ * `options.expiresAt` permette di seedare un invito già scaduto (default: +7 giorni).
+ */
+export async function seedPendingInviteByCode(
+  ownerId: string,
+  options?: { expiresAt?: Date },
+): Promise<{ listId: string; shortCode: string }> {
   const { data: list, error: listError } = await adminClient
     .from('lists')
     .insert({ created_by: ownerId, name: 'Lista codice E2E' })
@@ -158,22 +164,81 @@ export async function seedPendingInviteByCode(ownerId: string): Promise<{ listId
   if (listError || !list) throw new Error(`Impossibile creare la lista: ${listError?.message}`)
   await adminClient.from('list_members').insert({ list_id: list.id, user_id: ownerId })
   const shortCode = crypto.randomUUID().slice(0, 8).toUpperCase()
+  const expiresAt = options?.expiresAt ?? new Date(Date.now() + 7 * 24 * 3600 * 1000)
   const { error } = await adminClient.from('invites').insert({
     list_id: list.id,
     token: `e2e-${crypto.randomUUID()}`,
     short_code: shortCode,
     created_by: ownerId,
     status: 'pending',
-    expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+    // il check constraint `valid_expiry` impone expires_at > created_at: per
+    // seedare un invito già scaduto retrodatiamo anche created_at.
+    created_at: expiresAt < new Date() ? new Date(expiresAt.getTime() - 3600_000).toISOString() : undefined,
+    expires_at: expiresAt.toISOString(),
   })
   if (error) throw new Error(`Impossibile creare l'invito: ${error.message}`)
   return { listId: list.id, shortCode }
+}
+
+/**
+ * Crea un ulteriore invito pending per una lista GIÀ esistente (stesso owner).
+ * Usato per simulare un secondo link di invito verso una lista di cui l'utente
+ * è già membro (es. link riutilizzato/duplicato). Ritorna lo short_code.
+ */
+export async function seedAdditionalInviteForList(
+  listId: string,
+  ownerId: string,
+  options?: { expiresAt?: Date },
+): Promise<string> {
+  const shortCode = crypto.randomUUID().slice(0, 8).toUpperCase()
+  const { error } = await adminClient.from('invites').insert({
+    list_id: listId,
+    token: `e2e-${crypto.randomUUID()}`,
+    short_code: shortCode,
+    created_by: ownerId,
+    status: 'pending',
+    expires_at: (options?.expiresAt ?? new Date(Date.now() + 7 * 24 * 3600 * 1000)).toISOString(),
+  })
+  if (error) throw new Error(`Impossibile creare l'invito aggiuntivo: ${error.message}`)
+  return shortCode
 }
 
 /** True se la lista esiste ancora (via service-role). */
 export async function listExists(listId: string): Promise<boolean> {
   const { data } = await adminClient.from('lists').select('id').eq('id', listId).maybeSingle()
   return data !== null
+}
+
+/** True se l'utente risulta membro della lista indicata (via service-role). */
+export async function isMember(listId: string, userId: string): Promise<boolean> {
+  const { data } = await adminClient
+    .from('list_members')
+    .select('id')
+    .eq('list_id', listId)
+    .eq('user_id', userId)
+    .maybeSingle()
+  return data !== null
+}
+
+/** Numero di righe list_members per (lista, utente) — per verificare l'assenza di duplicati. */
+export async function countListMemberships(listId: string, userId: string): Promise<number> {
+  const { count, error } = await adminClient
+    .from('list_members')
+    .select('id', { count: 'exact', head: true })
+    .eq('list_id', listId)
+    .eq('user_id', userId)
+  if (error) throw new Error(`Impossibile contare le membership: ${error.message}`)
+  return count ?? 0
+}
+
+/** Stato corrente dell'invito identificato da short_code (via service-role). */
+export async function getInviteStatusByShortCode(shortCode: string): Promise<string | null> {
+  const { data } = await adminClient
+    .from('invites')
+    .select('status')
+    .eq('short_code', shortCode)
+    .maybeSingle()
+  return data?.status ?? null
 }
 
 /**

--- a/tests/e2e/helpers/supabase.ts
+++ b/tests/e2e/helpers/supabase.ts
@@ -147,3 +147,60 @@ export async function signInAsUser(email: string, password: string): Promise<Sup
   }
   return client
 }
+
+/** Crea una lista con owner e un invito pending con short_code noto. Ritorna { listId, shortCode }. */
+export async function seedPendingInviteByCode(ownerId: string): Promise<{ listId: string; shortCode: string }> {
+  const { data: list, error: listError } = await adminClient
+    .from('lists')
+    .insert({ created_by: ownerId, name: 'Lista codice E2E' })
+    .select('id')
+    .single()
+  if (listError || !list) throw new Error(`Impossibile creare la lista: ${listError?.message}`)
+  await adminClient.from('list_members').insert({ list_id: list.id, user_id: ownerId })
+  const shortCode = crypto.randomUUID().slice(0, 8).toUpperCase()
+  const { error } = await adminClient.from('invites').insert({
+    list_id: list.id,
+    token: `e2e-${crypto.randomUUID()}`,
+    short_code: shortCode,
+    created_by: ownerId,
+    status: 'pending',
+    expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+  })
+  if (error) throw new Error(`Impossibile creare l'invito: ${error.message}`)
+  return { listId: list.id, shortCode }
+}
+
+/** True se la lista esiste ancora (via service-role). */
+export async function listExists(listId: string): Promise<boolean> {
+  const { data } = await adminClient.from('lists').select('id').eq('id', listId).maybeSingle()
+  return data !== null
+}
+
+/**
+ * Aggiunge `n` foods a una lista (per testare food_count / cascade).
+ * `category_id` è FK obbligatoria verso `public.categories` (schema baseline
+ * 20260109): usiamo la categoria seed 'dairy'. `storage_location` accetta solo
+ * 'fridge' | 'freezer' | 'pantry' (check constraint), non le label italiane.
+ */
+export async function seedFoods(listId: string, ownerId: string, n: number): Promise<void> {
+  const { data: category, error: categoryError } = await adminClient
+    .from('categories')
+    .select('id')
+    .eq('name', 'dairy')
+    .single()
+  if (categoryError || !category) {
+    throw new Error(`Impossibile trovare la categoria seed 'dairy': ${categoryError?.message}`)
+  }
+  const rows = Array.from({ length: n }, (_, i) => ({
+    list_id: listId,
+    user_id: ownerId,
+    name: `Food E2E ${i}`,
+    category_id: category.id,
+    storage_location: 'fridge',
+    quantity: 1,
+    quantity_unit: 'pz',
+    expiry_date: new Date(Date.now() + 5 * 24 * 3600 * 1000).toISOString().slice(0, 10),
+  }))
+  const { error } = await adminClient.from('foods').insert(rows)
+  if (error) throw new Error(`Impossibile creare i foods: ${error.message}`)
+}

--- a/tests/e2e/helpers/supabase.ts
+++ b/tests/e2e/helpers/supabase.ts
@@ -1,11 +1,14 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const LOCAL_SUPABASE_URL = 'http://127.0.0.1:54321'
 const LOCAL_SERVICE_ROLE_KEY =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
+const LOCAL_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'
 
 const supabaseUrl = process.env.E2E_SUPABASE_URL ?? LOCAL_SUPABASE_URL
 const serviceRoleKey = process.env.E2E_SUPABASE_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_KEY
+const anonKey = process.env.E2E_SUPABASE_ANON_KEY ?? LOCAL_ANON_KEY
 
 const adminClient = createClient(supabaseUrl, serviceRoleKey, {
   auth: {
@@ -91,4 +94,28 @@ export async function makeUserListShared(userId: string, coMemberPassword: strin
   }
 
   return coMember
+}
+
+/**
+ * Client anonimo (ruolo `anon`), senza persistenza di sessione: usato come
+ * base per l'autenticazione via password nei test e2e.
+ */
+export function anonClient(): SupabaseClient {
+  return createClient(supabaseUrl, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}
+
+/**
+ * Autentica un client anonimo come l'utente indicato (email + password) e
+ * restituisce il client autenticato, da usare per esercitare RPC/RLS con i
+ * permessi reali dell'utente (non service-role).
+ */
+export async function signInAsUser(email: string, password: string): Promise<SupabaseClient> {
+  const client = anonClient()
+  const { error } = await client.auth.signInWithPassword({ email, password })
+  if (error) {
+    throw new Error(`Impossibile autenticarsi come ${email}: ${error.message}`)
+  }
+  return client
 }

--- a/tests/e2e/invite-join-security.spec.ts
+++ b/tests/e2e/invite-join-security.spec.ts
@@ -186,3 +186,29 @@ test('join_list_via_invite: force → swap, e la vecchia lista senza membri vien
     await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(joiner.email)
   }
 })
+
+test('SICUREZZA: insert diretto in list_members su lista altrui è negato', async () => {
+  const ownerEmail = createE2EEmail(); const owner = await createE2EUser(ownerEmail, password)
+  const attackerEmail = createE2EEmail(); const attacker = await createE2EUser(attackerEmail, password)
+  try {
+    const { listId } = await seedPendingInviteByCode(owner.id) // lista altrui con invito pending
+    const attackerClient = await signInAsUser(attackerEmail, password)
+    const { error } = await attackerClient.from('list_members').insert({ list_id: listId, user_id: attacker.id })
+    expect(error).not.toBeNull() // negato da RLS/revoke (42501 o simile)
+  } finally {
+    await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(attacker.email)
+  }
+})
+
+test('SICUREZZA: un authenticated non legge lo short_code di un invito altrui', async () => {
+  const ownerEmail = createE2EEmail(); const owner = await createE2EUser(ownerEmail, password)
+  const attackerEmail = createE2EEmail(); const attacker = await createE2EUser(attackerEmail, password)
+  try {
+    await seedPendingInviteByCode(owner.id)
+    const attackerClient = await signInAsUser(attackerEmail, password)
+    const { data } = await attackerClient.from('invites').select('short_code,list_id').eq('status', 'pending')
+    expect(data ?? []).toHaveLength(0) // non vede inviti che non lo riguardano
+  } finally {
+    await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(attacker.email)
+  }
+})

--- a/tests/e2e/invite-join-security.spec.ts
+++ b/tests/e2e/invite-join-security.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+import {
+  createE2EEmail,
+  createE2EUser,
+  deleteE2EUserByEmail,
+  signInAsUser,
+} from './helpers/supabase'
+
+const password = 'E2ePassword!2026'
+
+test.describe('sicurezza join list_members', () => {
+  test('un utente autenticato legge la propria lista', async () => {
+    const email = createE2EEmail()
+    const user = await createE2EUser(email, password)
+    try {
+      const client = await signInAsUser(email, password)
+      // create_personal_list è idempotente e crea la lista personale
+      const { data, error } = await client.rpc('create_personal_list')
+      expect(error).toBeNull()
+      expect(Array.isArray(data) ? data[0]?.success : (data as { success?: boolean })?.success).toBe(true)
+    } finally {
+      await deleteE2EUserByEmail(user.email)
+    }
+  })
+})

--- a/tests/e2e/invite-join-security.spec.ts
+++ b/tests/e2e/invite-join-security.spec.ts
@@ -3,6 +3,9 @@ import {
   createE2EEmail,
   createE2EUser,
   deleteE2EUserByEmail,
+  listExists,
+  seedFoods,
+  seedPendingInviteByCode,
   seedPendingInviteByEmail,
   signInAsUser,
 } from './helpers/supabase'
@@ -61,4 +64,70 @@ test.describe('sicurezza join list_members', () => {
       await deleteE2EUserByEmail(attacker.email)
     }
   })
+})
+
+test('join_list_via_invite: codice valido, nessuna lista → join', async () => {
+  const ownerEmail = createE2EEmail(); const owner = await createE2EUser(ownerEmail, password)
+  const joinerEmail = createE2EEmail(); const joiner = await createE2EUser(joinerEmail, password)
+  try {
+    const { listId, shortCode } = await seedPendingInviteByCode(owner.id)
+    const client = await signInAsUser(joinerEmail, password)
+    const { data } = await client.rpc('join_list_via_invite', { p_short_code: shortCode })
+    const row = Array.isArray(data) ? data[0] : data
+    expect(row?.success).toBe(true)
+    expect(row?.requires_confirmation).toBe(false)
+    expect(row?.list_id).toBe(listId)
+  } finally {
+    await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(joiner.email)
+  }
+})
+
+test('join_list_via_invite: codice inesistente → errore, nessun join', async () => {
+  const email = createE2EEmail(); const user = await createE2EUser(email, password)
+  try {
+    const client = await signInAsUser(email, password)
+    const { data } = await client.rpc('join_list_via_invite', { p_short_code: 'NOPE0000' })
+    const row = Array.isArray(data) ? data[0] : data
+    expect(row?.success).toBe(false)
+    expect(row?.error_message).toBeTruthy()
+  } finally { await deleteE2EUserByEmail(user.email) }
+})
+
+test('join_list_via_invite: utente con altra lista senza force → requires_confirmation + food_count', async () => {
+  const ownerEmail = createE2EEmail(); const owner = await createE2EUser(ownerEmail, password)
+  const joinerEmail = createE2EEmail(); const joiner = await createE2EUser(joinerEmail, password)
+  try {
+    // il joiner ha già una lista personale con 2 foods
+    const joinerClient = await signInAsUser(joinerEmail, password)
+    const { data: cpl } = await joinerClient.rpc('create_personal_list')
+    const joinerListId = (Array.isArray(cpl) ? cpl[0] : cpl)?.list_id as string
+    await seedFoods(joinerListId, joiner.id, 2)
+    const { shortCode } = await seedPendingInviteByCode(owner.id)
+    const { data } = await joinerClient.rpc('join_list_via_invite', { p_short_code: shortCode })
+    const row = Array.isArray(data) ? data[0] : data
+    expect(row?.requires_confirmation).toBe(true)
+    expect(row?.food_count).toBe(2)
+  } finally {
+    await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(joiner.email)
+  }
+})
+
+test('join_list_via_invite: force → swap, e la vecchia lista senza membri viene cancellata (cascade foods)', async () => {
+  const ownerEmail = createE2EEmail(); const owner = await createE2EUser(ownerEmail, password)
+  const joinerEmail = createE2EEmail(); const joiner = await createE2EUser(joinerEmail, password)
+  try {
+    const joinerClient = await signInAsUser(joinerEmail, password)
+    const { data: cpl } = await joinerClient.rpc('create_personal_list')
+    const oldListId = (Array.isArray(cpl) ? cpl[0] : cpl)?.list_id as string
+    await seedFoods(oldListId, joiner.id, 1)
+    const { listId: newListId, shortCode } = await seedPendingInviteByCode(owner.id)
+    const { data } = await joinerClient.rpc('join_list_via_invite', { p_short_code: shortCode, p_force: true })
+    const row = Array.isArray(data) ? data[0] : data
+    expect(row?.success).toBe(true)
+    expect(row?.list_id).toBe(newListId)
+    // la vecchia lista (ultimo membro rimosso) è stata cancellata → foods in cascade
+    expect(await listExists(oldListId)).toBe(false)
+  } finally {
+    await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(joiner.email)
+  }
 })

--- a/tests/e2e/invite-join-security.spec.ts
+++ b/tests/e2e/invite-join-security.spec.ts
@@ -1,9 +1,13 @@
 import { expect, test } from '@playwright/test'
 import {
+  countListMemberships,
   createE2EEmail,
   createE2EUser,
   deleteE2EUserByEmail,
+  getInviteStatusByShortCode,
+  isMember,
   listExists,
+  seedAdditionalInviteForList,
   seedFoods,
   seedPendingInviteByCode,
   seedPendingInviteByEmail,
@@ -102,11 +106,62 @@ test('join_list_via_invite: utente con altra lista senza force → requires_conf
     const { data: cpl } = await joinerClient.rpc('create_personal_list')
     const joinerListId = (Array.isArray(cpl) ? cpl[0] : cpl)?.list_id as string
     await seedFoods(joinerListId, joiner.id, 2)
-    const { shortCode } = await seedPendingInviteByCode(owner.id)
+    const { listId: invitedListId, shortCode } = await seedPendingInviteByCode(owner.id)
     const { data } = await joinerClient.rpc('join_list_via_invite', { p_short_code: shortCode })
     const row = Array.isArray(data) ? data[0] : data
     expect(row?.requires_confirmation).toBe(true)
     expect(row?.food_count).toBe(2)
+    // il ramo "richiede conferma" deve essere read-only: nessun side effect finché
+    // l'utente non conferma esplicitamente con p_force
+    expect(await isMember(joinerListId, joiner.id)).toBe(true) // ancora membro della propria lista
+    expect(await isMember(invitedListId, joiner.id)).toBe(false) // non ancora membro della lista invitata
+    expect(await getInviteStatusByShortCode(shortCode)).toBe('pending') // invito non consumato
+  } finally {
+    await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(joiner.email)
+  }
+})
+
+test('join_list_via_invite: codice scaduto → errore, invito marcato expired, nessun join', async () => {
+  const ownerEmail = createE2EEmail(); const owner = await createE2EUser(ownerEmail, password)
+  const joinerEmail = createE2EEmail(); const joiner = await createE2EUser(joinerEmail, password)
+  try {
+    const { listId, shortCode } = await seedPendingInviteByCode(owner.id, {
+      expiresAt: new Date(Date.now() - 60_000), // già scaduto
+    })
+    const client = await signInAsUser(joinerEmail, password)
+    const { data } = await client.rpc('join_list_via_invite', { p_short_code: shortCode })
+    const row = Array.isArray(data) ? data[0] : data
+    expect(row?.success).toBe(false)
+    expect(row?.error_message).toBeTruthy()
+    expect(await getInviteStatusByShortCode(shortCode)).toBe('expired') // marcato scaduto dalla RPC
+    expect(await isMember(listId, joiner.id)).toBe(false)
+  } finally {
+    await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(joiner.email)
+  }
+})
+
+test('join_list_via_invite: già membro della lista dell\'invito → success, invito accettato, nessuna membership duplicata', async () => {
+  const ownerEmail = createE2EEmail(); const owner = await createE2EUser(ownerEmail, password)
+  const joinerEmail = createE2EEmail(); const joiner = await createE2EUser(joinerEmail, password)
+  try {
+    // il joiner entra nella lista tramite un primo invito (join diretto, nessuna lista precedente)
+    const { listId, shortCode: firstCode } = await seedPendingInviteByCode(owner.id)
+    const client = await signInAsUser(joinerEmail, password)
+    const first = await client.rpc('join_list_via_invite', { p_short_code: firstCode })
+    const firstRow = Array.isArray(first.data) ? first.data[0] : first.data
+    expect(firstRow?.success).toBe(true)
+
+    // un secondo invito pending, ancora valido, punta alla STESSA lista di cui è già membro
+    // (es. link duplicato/riutilizzato) → deve attivare il ramo "già membro"
+    const secondCode = await seedAdditionalInviteForList(listId, owner.id)
+    const second = await client.rpc('join_list_via_invite', { p_short_code: secondCode })
+    const secondRow = Array.isArray(second.data) ? second.data[0] : second.data
+    expect(secondRow?.success).toBe(true)
+    expect(secondRow?.list_id).toBe(listId)
+    expect(await getInviteStatusByShortCode(secondCode)).toBe('accepted')
+
+    // nessuna riga list_members duplicata per (utente, lista)
+    expect(await countListMemberships(listId, joiner.id)).toBe(1)
   } finally {
     await deleteE2EUserByEmail(owner.email); await deleteE2EUserByEmail(joiner.email)
   }

--- a/tests/e2e/invite-join-security.spec.ts
+++ b/tests/e2e/invite-join-security.spec.ts
@@ -3,6 +3,7 @@ import {
   createE2EEmail,
   createE2EUser,
   deleteE2EUserByEmail,
+  seedPendingInviteByEmail,
   signInAsUser,
 } from './helpers/supabase'
 
@@ -20,6 +21,44 @@ test.describe('sicurezza join list_members', () => {
       expect(Array.isArray(data) ? data[0]?.success : (data as { success?: boolean })?.success).toBe(true)
     } finally {
       await deleteE2EUserByEmail(user.email)
+    }
+  })
+
+  test('accept_pending_invite_by_email: joina l\'invito per la propria email', async () => {
+    const inviterEmail = createE2EEmail()
+    const inviter = await createE2EUser(inviterEmail, password)
+    const inviteeEmail = createE2EEmail()
+    const invitee = await createE2EUser(inviteeEmail, password)
+    try {
+      const listId = await seedPendingInviteByEmail(inviter.id, inviteeEmail)
+      const client = await signInAsUser(inviteeEmail, password)
+      const { data, error } = await client.rpc('accept_pending_invite_by_email')
+      const row = Array.isArray(data) ? data[0] : data
+      expect(error).toBeNull()
+      expect(row?.success).toBe(true)
+      expect(row?.list_id).toBe(listId)
+    } finally {
+      await deleteE2EUserByEmail(inviter.email)
+      await deleteE2EUserByEmail(invitee.email)
+    }
+  })
+
+  test('accept_pending_invite_by_email: NON joina un invito per un\'altra email', async () => {
+    const inviterEmail = createE2EEmail()
+    const inviter = await createE2EUser(inviterEmail, password)
+    const otherEmail = createE2EEmail()
+    const attackerEmail = createE2EEmail()
+    const attacker = await createE2EUser(attackerEmail, password)
+    try {
+      await seedPendingInviteByEmail(inviter.id, otherEmail) // invito per otherEmail, non per l'attaccante
+      const client = await signInAsUser(attackerEmail, password)
+      const { data } = await client.rpc('accept_pending_invite_by_email')
+      const row = Array.isArray(data) ? data[0] : data
+      expect(row?.success).toBe(false) // no-op: nessun invito per la sua email
+      expect(row?.list_id ?? null).toBeNull()
+    } finally {
+      await deleteE2EUserByEmail(inviter.email)
+      await deleteE2EUserByEmail(attacker.email)
     }
   })
 })


### PR DESCRIPTION
Chiude #70 (un utente autenticato poteva auto-aggiungersi a liste arbitrarie via insert diretto su `list_members`) e #71 (harvest degli inviti `pending`/`short_code` altrui). ⚠️ **Non fondere/deployare in produzione senza backup** — la migration è additiva ma cambia policy/GRANT su tabelle con dati reali (come #69): prima del `supabase db push`, `supabase db dump` completo.

## Cosa cambia

- **Nuove RPC `SECURITY DEFINER`** (`search_path=''`, GRANT EXECUTE espliciti):
  - `join_list_via_invite(p_short_code, p_force)` — accept per codice con logica single-list (conferma + `food_count`, force-swap con cancellazione della vecchia lista se resta senza membri). Porta server-side la logica prima nel client.
  - `accept_pending_invite_by_email()` — auto-accept dell'invito indirizzato alla **propria** email (autoritativa da `auth.users`, mai dal JWT). Non joina inviti per altri.
  - helper `current_user_email()`.
- **Write hardening `list_members`:** drop della policy INSERT permissiva + `REVOKE INSERT ... FROM authenticated`. Restano SELECT (proprie liste) e DELETE (self-leave). Le RPC (definer) e `create_personal_list` continuano a funzionare.
- **Read hardening `invites`:** SELECT ristretta a `list_id ∈ proprie liste OR pending_user_email = propria email`; UPDATE client revocata. Niente più harvest di `short_code` altrui.
- **Client (`src/lib/invites.ts`):** `acceptInviteByEmail` / `acceptInviteWithConfirmation` ora chiamano le RPC; rimossa la logica DB diretta. Tipi in `supabase.types.ts`.
- **Test:** nuovo `tests/e2e/invite-join-security.spec.ts` (client autenticati reali contro Supabase locale) — 2 test SICUREZZA (insert diretto negato, short_code non leggibile) + rami join/by-email (valido, scaduto, già-membro, conferma, force-swap distruttivo, cross-email negato). CHANGELOG `[1.10.3]` + bump.

## Nota di design (non-ovvia)

`REVOKE INSERT`/drop policy **non** rompono le RPC: una funzione `SECURITY DEFINER` gira come owner, bypassando GRANT/RLS del caller (verificato sulla doc ufficiale Supabase). `auth.uid()`/l'email sono comunque quelli del **caller**.

## Sviluppo

Implementato con revisione a due stadi per task (subagent-driven) + review finale dell'intero branch: *Ready to merge: Yes*, 5/5 invarianti di sicurezza verificate. Follow-up non bloccanti tracciati in #74.

## Verifiche

- [x] `npm run lint` (0 errori, warning pre-esistenti)
- [x] `npm run typecheck`
- [x] `npm test` (unit 240/240)
- [x] `npm run build`
- [x] e2e Playwright 13/13 (incl. `invite-join-security`)

## Database e sicurezza

- [ ] Nessuna modifica database
- [x] Migration additiva con RLS e GRANT espliciti
- [x] Autorizzazione e azioni distruttive coperte da test (insert diretto negato; force-swap/cancellazione ultima lista testati)

## UI/mobile

- [x] Nessuna modifica UI
- [ ] Verificata in viewport mobile
- [x] Testi e documentazione aggiornati (CHANGELOG)