### PR TITLE
refactor(filtri): il vocabolario dei filtri parla di scadenza, non di stato (v1.10.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.10.5] - 2026-08-11
+
+### Changed
+- Il filtro della dashboard non si chiama più «stato» ma «scadenza», nel codice e nell'interfaccia. Sulla tabella `foods` convivono due assi indipendenti: `deleted_at` («lo traccio ancora?») e `status` («com'è finita?», con i valori `active`/`consumed`/`expired`/`wasted`). Il filtro non ha mai letto la colonna `status` — confronta `expiry_date` con la data di oggi — e chiamarlo «stato» faceva sembrare collegate due cose che non lo sono. `FilterParams.status` diventa quindi `FilterParams.expiry`, con i valori `all | not_expired | expiring_soon | expired`.
+- Nell'interfaccia, l'etichetta del gruppo passa da «Stato» a «Scadenza» e l'opzione «✅ Attivi» diventa «✅ Non scaduti». È la metà visibile della stessa ambiguità: quell'opzione ha sempre filtrato per «non scaduto», mentre «Attivi» richiamava il valore `active` del ciclo di vita, che è un'altra cosa.
+- I link già salvati e condivisi continuano a funzionare: il vecchio parametro `?status=` resta accettato in lettura, e `status=active` viene tradotto in `expiry=not_expired` conservando il significato e non la parola. In scrittura l'URL usa solo il nome nuovo. La mappatura vive ora in `src/lib/foodFilterParams.ts`, estratta dalla dashboard perché una promessa verso link esterni va coperta da test senza dover montare l'intera pagina.
+
+### Fixed
+- Un parametro d'URL fuori vocabolario non svuota più la lista: `?storage=banana` finiva così com'era nel confronto con `food.storage_location` e non lasciava passare nessun alimento. Ora ogni parametro non riconosciuto (`storage`, `expiry`, `sortBy`, `sortOrder`) torna al proprio default. Per `sortBy` e `sortOrder` il valore non validato era finora innocuo a valle, ma passava comunque.
+
 ## [1.10.4] - 2026-08-07
 
 ### Fixed
@@ -481,7 +491,8 @@ Lancio pubblico di Entro su LinkedIn.
 - Sistema di autenticazione Supabase completo
 - CRUD completo gestione alimenti con React Query
 
-[Unreleased]: https://github.com/E-Lop/entro/compare/v1.10.4...HEAD
+[Unreleased]: https://github.com/E-Lop/entro/compare/v1.10.5...HEAD
+[1.10.5]: https://github.com/E-Lop/entro/compare/v1.10.4...v1.10.5
 [1.10.4]: https://github.com/E-Lop/entro/compare/v1.10.3...v1.10.4
 [1.10.3]: https://github.com/E-Lop/entro/compare/v1.10.2...v1.10.3
 [1.10.2]: https://github.com/E-Lop/entro/compare/v1.10.1...v1.10.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.10.4",
+  "version": "1.10.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/foods/DashboardStats.tsx
+++ b/src/components/foods/DashboardStats.tsx
@@ -4,25 +4,26 @@ import type { FilterParams } from '@/lib/foods'
 
 interface DashboardStatsProps {
   stats: { total: number; expiringSoon: number; expired: number }
-  currentStatus: FilterParams['status']
-  onQuickFilter: (status: 'all' | 'expiring_soon' | 'expired') => void
+  currentExpiry: FilterParams['expiry']
+  onQuickFilter: (expiry: 'all' | 'expiring_soon' | 'expired') => void
 }
 
 const STAT_CARD_BASE =
   "text-left transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg border bg-card text-card-foreground shadow"
 const STAT_CARD_SELECTED = 'ring-2 ring-primary'
 
-export function DashboardStats({ stats, currentStatus, onQuickFilter }: DashboardStatsProps) {
+export function DashboardStats({ stats, currentExpiry, onQuickFilter }: DashboardStatsProps) {
+  // Nessun filtro e filtro `all` sono la stessa selezione: normalizzarli qui
+  // evita di ripetere il doppio confronto su ogni card.
+  const selected = currentExpiry ?? 'all'
+
   return (
     <div className="grid grid-cols-3 gap-3" role="group" aria-label="Statistiche rapide">
       <button
         onClick={() => onQuickFilter('all')}
-        className={cn(
-          STAT_CARD_BASE,
-          (!currentStatus || currentStatus === 'all') && STAT_CARD_SELECTED
-        )}
+        className={cn(STAT_CARD_BASE, selected === 'all' && STAT_CARD_SELECTED)}
         aria-label={`Mostra tutti gli alimenti (${stats.total})`}
-        aria-pressed={!currentStatus || currentStatus === 'all'}
+        aria-pressed={selected === 'all'}
       >
         <div className="p-4 flex flex-col items-center text-center">
           <ShoppingBasket className="h-6 w-6 text-muted-foreground mb-2" aria-hidden="true" />
@@ -33,12 +34,9 @@ export function DashboardStats({ stats, currentStatus, onQuickFilter }: Dashboar
 
       <button
         onClick={() => onQuickFilter('expiring_soon')}
-        className={cn(
-          STAT_CARD_BASE,
-          currentStatus === 'expiring_soon' && STAT_CARD_SELECTED
-        )}
+        className={cn(STAT_CARD_BASE, selected === 'expiring_soon' && STAT_CARD_SELECTED)}
         aria-label={`Mostra alimenti in scadenza (${stats.expiringSoon})`}
-        aria-pressed={currentStatus === 'expiring_soon'}
+        aria-pressed={selected === 'expiring_soon'}
       >
         <div className="p-4 flex flex-col items-center text-center">
           <CalendarDays className="h-6 w-6 text-warning mb-2" aria-hidden="true" />
@@ -49,12 +47,9 @@ export function DashboardStats({ stats, currentStatus, onQuickFilter }: Dashboar
 
       <button
         onClick={() => onQuickFilter('expired')}
-        className={cn(
-          STAT_CARD_BASE,
-          currentStatus === 'expired' && STAT_CARD_SELECTED
-        )}
+        className={cn(STAT_CARD_BASE, selected === 'expired' && STAT_CARD_SELECTED)}
         aria-label={`Mostra alimenti scaduti (${stats.expired})`}
-        aria-pressed={currentStatus === 'expired'}
+        aria-pressed={selected === 'expired'}
       >
         <div className="p-4 flex flex-col items-center text-center">
           <AlertTriangle className="h-6 w-6 text-destructive mb-2" aria-hidden="true" />

--- a/src/components/foods/FoodFilters.tsx
+++ b/src/components/foods/FoodFilters.tsx
@@ -24,7 +24,7 @@ export interface FoodFiltersProps {
  * - Search by name (debounced in parent component)
  * - Filter by category
  * - Filter by storage location
- * - Filter by status (active, expired, expiring soon)
+ * - Filter by expiry (not expired, expiring soon, expired)
  * - Sort by various fields
  * - Active filters badge
  * - Clear all filters button
@@ -53,10 +53,10 @@ export function FoodFilters({
     })
   }
 
-  const handleStatusChange = (value: string) => {
+  const handleExpiryChange = (value: string) => {
     onFiltersChange({
       ...filters,
-      status: value ? (value as 'all' | 'active' | 'expired' | 'expiring_soon') : 'all',
+      expiry: value ? (value as NonNullable<FilterParams['expiry']>) : 'all',
     })
   }
 
@@ -168,17 +168,17 @@ export function FoodFilters({
                   </select>
                 </div>
 
-                {/* Status Filter */}
+                {/* Expiry Filter */}
                 <div className="space-y-2">
-                  <Label htmlFor="status">Stato</Label>
+                  <Label htmlFor="expiry">Scadenza</Label>
                   <select
-                    id="status"
-                    value={filters.status || 'all'}
-                    onChange={(e) => handleStatusChange(e.target.value)}
+                    id="expiry"
+                    value={filters.expiry || 'all'}
+                    onChange={(e) => handleExpiryChange(e.target.value)}
                     className={selectClassName}
                   >
                     <option value="all">Tutti</option>
-                    <option value="active">✅ Attivi</option>
+                    <option value="not_expired">✅ Non scaduti</option>
                     <option value="expiring_soon">⏰ In scadenza (7gg)</option>
                     <option value="expired">❌ Scaduti</option>
                   </select>

--- a/src/components/foods/__tests__/DashboardStats.test.tsx
+++ b/src/components/foods/__tests__/DashboardStats.test.tsx
@@ -10,7 +10,7 @@ const STATS = { total: 4, expiringSoon: 3, expired: 1 }
 describe('DashboardStats — quick filter', () => {
   it('invoca onQuickFilter con lo stato corretto al click', () => {
     const onQuickFilter = vi.fn()
-    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={onQuickFilter} />)
+    render(<DashboardStats stats={STATS} currentExpiry="all" onQuickFilter={onQuickFilter} />)
 
     fireEvent.click(screen.getByRole('button', { name: /Mostra alimenti in scadenza/ }))
     expect(onQuickFilter).toHaveBeenCalledWith('expiring_soon')
@@ -23,7 +23,7 @@ describe('DashboardStats — quick filter', () => {
   })
 
   it('espone i conteggi nelle aria-label', () => {
-    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />)
+    render(<DashboardStats stats={STATS} currentExpiry="all" onQuickFilter={vi.fn()} />)
     expect(screen.getByRole('button', { name: /Mostra tutti gli alimenti \(4\)/ })).toBeTruthy()
     expect(screen.getByRole('button', { name: /Mostra alimenti in scadenza \(3\)/ })).toBeTruthy()
     expect(screen.getByRole('button', { name: /Mostra alimenti scaduti \(1\)/ })).toBeTruthy()
@@ -33,27 +33,27 @@ describe('DashboardStats — quick filter', () => {
 describe('DashboardStats — identità di brand (una sola voce)', () => {
   it('evidenzia la card selezionata con il ring verde brand, mai blu', () => {
     const { rerender } = render(
-      <DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />
+      <DashboardStats stats={STATS} currentExpiry="all" onQuickFilter={vi.fn()} />
     )
     const all = screen.getByRole('button', { name: /Mostra tutti gli alimenti/ })
     expect(all.className).toContain('ring-primary')
     expect(all.getAttribute('aria-pressed')).toBe('true')
 
-    rerender(<DashboardStats stats={STATS} currentStatus="expired" onQuickFilter={vi.fn()} />)
+    rerender(<DashboardStats stats={STATS} currentExpiry="expired" onQuickFilter={vi.fn()} />)
     const expired = screen.getByRole('button', { name: /Mostra alimenti scaduti/ })
     expect(expired.className).toContain('ring-primary')
     expect(expired.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('non usa nessun ring blu/arancio/rosso fuori-brand per la selezione', () => {
-    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />)
+    render(<DashboardStats stats={STATS} currentExpiry="all" onQuickFilter={vi.fn()} />)
     for (const btn of screen.getAllByRole('button')) {
       expect(btn.className).not.toMatch(/ring-(blue|orange|red)-\d/)
     }
   })
 
   it('imposta aria-pressed=false sulle card non selezionate', () => {
-    render(<DashboardStats stats={STATS} currentStatus="all" onQuickFilter={vi.fn()} />)
+    render(<DashboardStats stats={STATS} currentExpiry="all" onQuickFilter={vi.fn()} />)
     expect(
       screen.getByRole('button', { name: /Mostra alimenti scaduti/ }).getAttribute('aria-pressed')
     ).toBe('false')

--- a/src/components/foods/__tests__/FoodFilters.test.tsx
+++ b/src/components/foods/__tests__/FoodFilters.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { FoodFilters } from '../FoodFilters'
 import type { FilterParams } from '@/lib/foods'
 
@@ -21,6 +21,38 @@ describe('FoodFilters — badge filtri attivi (identità brand)', () => {
     const badge = screen.getByText('2')
     expect(badge.className).not.toMatch(/blue/)
     expect(badge.className).toMatch(/primary/)
+  })
+})
+
+describe('FoodFilters — il filtro si chiama scadenza, non stato', () => {
+  it('etichetta il gruppo «Scadenza» e l\'opzione «Non scaduti»', () => {
+    // Il filtro guarda `expiry_date`, non la colonna `status` del ciclo di
+    // vita: «Attivi» richiamava il valore `active` di quest'ultima.
+    render(<FoodFilters {...baseProps} activeFiltersCount={0} isExpanded={true} />)
+
+    const select = screen.getByLabelText('Scadenza')
+    expect(screen.queryByLabelText('Stato')).toBeNull()
+    expect([...select.querySelectorAll('option')].map(o => o.textContent)).toEqual([
+      'Tutti',
+      '✅ Non scaduti',
+      '⏰ In scadenza (7gg)',
+      '❌ Scaduti',
+    ])
+  })
+
+  it('emette il filtro sotto la chiave `expiry`', () => {
+    const onFiltersChange = vi.fn()
+    render(
+      <FoodFilters
+        {...baseProps}
+        activeFiltersCount={0}
+        isExpanded={true}
+        onFiltersChange={onFiltersChange}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText('Scadenza'), { target: { value: 'not_expired' } })
+    expect(onFiltersChange).toHaveBeenCalledWith({ expiry: 'not_expired' })
   })
 })
 

--- a/src/lib/__tests__/foodFilterParams.test.ts
+++ b/src/lib/__tests__/foodFilterParams.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Mappatura fra i parametri d'URL della dashboard e FilterParams.
+ *
+ * Esiste come modulo a sé perché la retrocompatibilità del vecchio parametro
+ * `?status=` è una promessa verso link già salvati e condivisi: va provata,
+ * e provarla dentro un `useMemo` della pagina vorrebbe dire montare tutta la
+ * dashboard per verificare una traduzione di stringhe.
+ */
+import { describe, it, expect } from 'vitest'
+import { parseFilterParams, buildSearchParams } from '@/lib/foodFilterParams'
+
+function params(query: string): URLSearchParams {
+  return new URLSearchParams(query)
+}
+
+describe('parseFilterParams', () => {
+  it('legge il parametro nuovo', () => {
+    expect(parseFilterParams(params('expiry=expired')).expiry).toBe('expired')
+  })
+
+  it('vale "all" quando il parametro manca', () => {
+    expect(parseFilterParams(params('')).expiry).toBe('all')
+  })
+
+  it('accetta ancora il vecchio ?status=, che sta nei link salvati', () => {
+    expect(parseFilterParams(params('status=expired')).expiry).toBe('expired')
+  })
+
+  it('traduce il vecchio valore "active" nel nuovo "not_expired"', () => {
+    // Il vecchio `active` non voleva dire "non concluso" come nel ciclo di
+    // vita, ma "non scaduto": la traduzione conserva il significato, non la
+    // parola.
+    expect(parseFilterParams(params('status=active')).expiry).toBe('not_expired')
+  })
+
+  it('preferisce il parametro nuovo quando ci sono entrambi', () => {
+    expect(parseFilterParams(params('status=active&expiry=expired')).expiry).toBe('expired')
+  })
+
+  it('ignora un valore che non appartiene al vocabolario', () => {
+    expect(parseFilterParams(params('expiry=banana')).expiry).toBe('all')
+  })
+
+  it('scarta un valore fuori vocabolario anche sugli altri filtri', () => {
+    // Prima la pagina si fidava dell'URL e passava il valore così com'era:
+    // `?storage=banana` finiva nel confronto e svuotava la lista. Ora un
+    // parametro che non appartiene al vocabolario torna al suo default.
+    const filters = parseFilterParams(params('storage=banana&sortBy=banana&sortOrder=banana'))
+
+    expect(filters.storage_location).toBeUndefined()
+    expect(filters.sortBy).toBe('expiry_date')
+    expect(filters.sortOrder).toBe('asc')
+  })
+
+  it('legge anche gli altri filtri', () => {
+    const filters = parseFilterParams(
+      params('category=c1&storage=fridge&search=latte&sortBy=name&sortOrder=desc')
+    )
+
+    expect(filters).toMatchObject({
+      category_id: 'c1',
+      storage_location: 'fridge',
+      search: 'latte',
+      sortBy: 'name',
+      sortOrder: 'desc',
+    })
+  })
+})
+
+describe('buildSearchParams', () => {
+  it('scrive il parametro nuovo', () => {
+    expect(buildSearchParams({ expiry: 'expired' }).get('expiry')).toBe('expired')
+  })
+
+  it('non scrive più il vecchio nome, nemmeno insieme al nuovo', () => {
+    expect(buildSearchParams({ expiry: 'expired' }).get('status')).toBeNull()
+  })
+
+  it('omette il filtro quando vale "all", per non sporcare l\'URL', () => {
+    expect(buildSearchParams({ expiry: 'all' }).get('expiry')).toBeNull()
+  })
+
+  it('scrive solo i filtri che riceve', () => {
+    // È la proprietà su cui si appoggiano le card delle statistiche: passano
+    // il solo `expiry` proprio per azzerare gli altri filtri.
+    expect([...buildSearchParams({ expiry: 'expired' }).keys()]).toEqual(['expiry'])
+    expect([...buildSearchParams({ expiry: 'all' }).keys()]).toEqual([])
+  })
+
+  it('fa il giro completo: quello che scrive, sa rileggerlo', () => {
+    const originali = {
+      category_id: 'c1',
+      storage_location: 'freezer' as const,
+      expiry: 'expiring_soon' as const,
+      search: 'pane',
+      sortBy: 'name' as const,
+      sortOrder: 'desc' as const,
+    }
+
+    expect(parseFilterParams(buildSearchParams(originali))).toMatchObject(originali)
+  })
+})

--- a/src/lib/__tests__/foodFilters.test.ts
+++ b/src/lib/__tests__/foodFilters.test.ts
@@ -32,41 +32,41 @@ const foods: Food[] = [
   makeFood({ name: 'Ricotta', expiry_date: dExpired, category_id: 'c1', storage_location: 'fridge' }),
 ]
 
-describe('filterFoods - stato (business rule + confini)', () => {
+describe('filterFoods - scadenza (business rule + confini)', () => {
   it('all → tutti', () => {
-    expect(filterFoods(foods, { status: 'all' }, NOW)).toHaveLength(5)
+    expect(filterFoods(foods, { expiry: 'all' }, NOW)).toHaveLength(5)
   })
   it('expiring_soon → oggi/soon/this_week (0..7 giorni)', () => {
-    const names = filterFoods(foods, { status: 'expiring_soon' }, NOW).map(f => f.name).sort()
+    const names = filterFoods(foods, { expiry: 'expiring_soon' }, NOW).map(f => f.name).sort()
     expect(names).toEqual(['Latte', 'Pane', 'Yogurt'])
   })
   it('expired → solo passato', () => {
-    expect(filterFoods(foods, { status: 'expired' }, NOW).map(f => f.name)).toEqual(['Ricotta'])
+    expect(filterFoods(foods, { expiry: 'expired' }, NOW).map(f => f.name)).toEqual(['Ricotta'])
   })
-  it('active → tutto tranne lo scaduto', () => {
-    const names = filterFoods(foods, { status: 'active' }, NOW).map(f => f.name).sort()
+  it('not_expired → tutto tranne lo scaduto', () => {
+    const names = filterFoods(foods, { expiry: 'not_expired' }, NOW).map(f => f.name).sort()
     expect(names).toEqual(['Latte', 'Pane', 'Tonno', 'Yogurt'])
   })
   it('confine: +8 giorni è fresh, non expiring_soon', () => {
-    expect(filterFoods([makeFood({ name: 'X', expiry_date: dFresh })], { status: 'expiring_soon' }, NOW)).toHaveLength(0)
+    expect(filterFoods([makeFood({ name: 'X', expiry_date: dFresh })], { expiry: 'expiring_soon' }, NOW)).toHaveLength(0)
   })
 })
 
 describe('filterFoods - categoria / posizione / ricerca', () => {
   it('category_id match esatto', () => {
-    expect(filterFoods(foods, { status: 'all', category_id: 'c2' }, NOW).map(f => f.name).sort()).toEqual(['Pane', 'Tonno'])
+    expect(filterFoods(foods, { expiry: 'all', category_id: 'c2' }, NOW).map(f => f.name).sort()).toEqual(['Pane', 'Tonno'])
   })
   it('storage_location match esatto', () => {
-    expect(filterFoods(foods, { status: 'all', storage_location: 'pantry' }, NOW).map(f => f.name).sort()).toEqual(['Pane', 'Tonno'])
+    expect(filterFoods(foods, { expiry: 'all', storage_location: 'pantry' }, NOW).map(f => f.name).sort()).toEqual(['Pane', 'Tonno'])
   })
   it('search substring case-insensitive con trim', () => {
-    expect(filterFoods(foods, { status: 'all', search: '  YOG ' }, NOW).map(f => f.name)).toEqual(['Yogurt'])
+    expect(filterFoods(foods, { expiry: 'all', search: '  YOG ' }, NOW).map(f => f.name)).toEqual(['Yogurt'])
   })
   it('search vuota = nessun filtro', () => {
-    expect(filterFoods(foods, { status: 'all', search: '   ' }, NOW)).toHaveLength(5)
+    expect(filterFoods(foods, { expiry: 'all', search: '   ' }, NOW)).toHaveLength(5)
   })
-  it('combina filtri: categoria + stato', () => {
-    const names = filterFoods(foods, { status: 'expiring_soon', category_id: 'c1' }, NOW).map(f => f.name).sort()
+  it('combina filtri: categoria + scadenza', () => {
+    const names = filterFoods(foods, { expiry: 'expiring_soon', category_id: 'c1' }, NOW).map(f => f.name).sort()
     expect(names).toEqual(['Latte', 'Yogurt'])
   })
 })
@@ -100,8 +100,8 @@ describe('sortFoods', () => {
 })
 
 describe('deriveDashboardData', () => {
-  it('stats riflettono i filtri non-stato; lista applica anche lo stato', () => {
-    const { foods: list, stats } = deriveDashboardData(foods, { status: 'expiring_soon', sortBy: 'expiry_date', sortOrder: 'asc' }, NOW)
+  it('stats ignorano il filtro scadenza; la lista invece lo applica', () => {
+    const { foods: list, stats } = deriveDashboardData(foods, { expiry: 'expiring_soon', sortBy: 'expiry_date', sortOrder: 'asc' }, NOW)
     expect(stats.total).toBe(5)
     expect(stats.expiringSoon).toBe(3)
     expect(stats.expired).toBe(1)
@@ -109,7 +109,7 @@ describe('deriveDashboardData', () => {
     expect(list.length).toBe(stats.expiringSoon)
   })
   it('i conteggi rispettano un filtro categoria attivo', () => {
-    const { stats } = deriveDashboardData(foods, { status: 'all', category_id: 'c1' }, NOW)
+    const { stats } = deriveDashboardData(foods, { expiry: 'all', category_id: 'c1' }, NOW)
     expect(stats.total).toBe(3)
     expect(stats.expiringSoon).toBe(2)
     expect(stats.expired).toBe(1)

--- a/src/lib/foodFilterParams.ts
+++ b/src/lib/foodFilterParams.ts
@@ -1,0 +1,86 @@
+// Mappatura fra i parametri d'URL della dashboard e FilterParams.
+//
+// Estratta dalla pagina perché contiene una promessa verso l'esterno: il
+// vecchio parametro `?status=` sta in link salvati e condivisi, e va
+// continuato ad accettare in lettura anche ora che il nome interno è `expiry`.
+// Una promessa del genere va provata, e provarla dentro un `useMemo` della
+// dashboard vorrebbe dire montare l'intera pagina per verificare una
+// traduzione di stringhe.
+import type { FilterParams } from '@/lib/foods'
+
+type ExpiryFilter = NonNullable<FilterParams['expiry']>
+
+const EXPIRY_VALUES: readonly ExpiryFilter[] = [
+  'all',
+  'not_expired',
+  'expiring_soon',
+  'expired',
+]
+
+/**
+ * Vecchio vocabolario del parametro `?status=` → nuovo.
+ *
+ * L'unica traduzione vera è `active` → `not_expired`: nel vecchio nome
+ * significava «non scaduto», che è cosa diversa dall'`active` del ciclo di
+ * vita («non ancora concluso»). Si conserva il significato, non la parola.
+ */
+const LEGACY_EXPIRY: Readonly<Record<string, ExpiryFilter>> = {
+  all: 'all',
+  active: 'not_expired',
+  expiring_soon: 'expiring_soon',
+  expired: 'expired',
+}
+
+const STORAGE_VALUES: readonly NonNullable<FilterParams['storage_location']>[] = [
+  'fridge',
+  'freezer',
+  'pantry',
+]
+
+const SORT_BY_VALUES: readonly NonNullable<FilterParams['sortBy']>[] = [
+  'expiry_date',
+  'name',
+  'created_at',
+  'category_id',
+]
+
+/** Restituisce il valore solo se appartiene al vocabolario, altrimenti niente. */
+function pick<T extends string>(value: string | null, allowed: readonly T[]): T | undefined {
+  return allowed.find((candidate) => candidate === value)
+}
+
+/** Il nuovo nome vince; il vecchio resta come ripiego per i link già in giro. */
+function readExpiry(params: URLSearchParams): ExpiryFilter {
+  const current = pick(params.get('expiry'), EXPIRY_VALUES)
+  if (current) return current
+
+  const legacy = params.get('status')
+  if (legacy !== null && legacy in LEGACY_EXPIRY) return LEGACY_EXPIRY[legacy]
+
+  return 'all'
+}
+
+export function parseFilterParams(params: URLSearchParams): FilterParams {
+  return {
+    category_id: params.get('category') || undefined,
+    storage_location: pick(params.get('storage'), STORAGE_VALUES),
+    expiry: readExpiry(params),
+    search: params.get('search') || undefined,
+    sortBy: pick(params.get('sortBy'), SORT_BY_VALUES) ?? 'expiry_date',
+    sortOrder: params.get('sortOrder') === 'desc' ? 'desc' : 'asc',
+  }
+}
+
+export function buildSearchParams(filters: FilterParams): URLSearchParams {
+  const params = new URLSearchParams()
+
+  if (filters.category_id) params.set('category', filters.category_id)
+  if (filters.storage_location) params.set('storage', filters.storage_location)
+  // `all` è il valore di riposo: scriverlo sporcherebbe l'URL senza dire nulla.
+  if (filters.expiry && filters.expiry !== 'all') params.set('expiry', filters.expiry)
+  if (filters.search) params.set('search', filters.search)
+  if (filters.sortBy) params.set('sortBy', filters.sortBy)
+  if (filters.sortOrder) params.set('sortOrder', filters.sortOrder)
+
+  return params
+}

--- a/src/lib/foodFilters.ts
+++ b/src/lib/foodFilters.ts
@@ -4,18 +4,18 @@
 import type { Food, FilterParams } from '@/lib/foods'
 import { getExpiryStatus, isExpiringSoon, isExpired } from '@/lib/expiry'
 
-/** Applica categoria, posizione, ricerca (substring case-insensitive) e stato. */
+/** Applica categoria, posizione, ricerca (substring case-insensitive) e scadenza. */
 export function filterFoods(foods: Food[], filters: FilterParams, now: Date = new Date()): Food[] {
   const search = filters.search?.trim().toLowerCase()
   return foods.filter((food) => {
     if (filters.category_id && food.category_id !== filters.category_id) return false
     if (filters.storage_location && food.storage_location !== filters.storage_location) return false
     if (search && !food.name.toLowerCase().includes(search)) return false
-    if (filters.status && filters.status !== 'all') {
+    if (filters.expiry && filters.expiry !== 'all') {
       const status = getExpiryStatus(food.expiry_date, now)
-      if (filters.status === 'expired') return isExpired(status)
-      if (filters.status === 'expiring_soon') return isExpiringSoon(status)
-      if (filters.status === 'active') return !isExpired(status)
+      if (filters.expiry === 'expired') return isExpired(status)
+      if (filters.expiry === 'expiring_soon') return isExpiringSoon(status)
+      if (filters.expiry === 'not_expired') return !isExpired(status)
     }
     return true
   })
@@ -46,11 +46,11 @@ export interface DashboardData {
 
 /**
  * Deriva lista mostrata + conteggi card dalla stessa lista in cache.
- * I conteggi riflettono i filtri categoria/posizione/ricerca attivi (non lo stato);
- * la lista applica anche lo stato e l'ordinamento.
+ * I conteggi riflettono i filtri categoria/posizione/ricerca attivi (non la scadenza);
+ * la lista applica anche la scadenza e l'ordinamento.
  */
 export function deriveDashboardData(allFoods: Food[], filters: FilterParams, now: Date = new Date()): DashboardData {
-  const scoped = filterFoods(allFoods, { ...filters, status: 'all' }, now)
+  const scoped = filterFoods(allFoods, { ...filters, expiry: 'all' }, now)
   let expiringSoon = 0
   let expired = 0
   for (const food of scoped) {
@@ -58,6 +58,6 @@ export function deriveDashboardData(allFoods: Food[], filters: FilterParams, now
     if (isExpiringSoon(status)) expiringSoon++
     if (isExpired(status)) expired++
   }
-  const foods = sortFoods(filterFoods(scoped, { status: filters.status }, now), filters.sortBy, filters.sortOrder)
+  const foods = sortFoods(filterFoods(scoped, { expiry: filters.expiry }, now), filters.sortBy, filters.sortOrder)
   return { foods, stats: { total: scoped.length, expiringSoon, expired } }
 }

--- a/src/lib/foods.ts
+++ b/src/lib/foods.ts
@@ -34,7 +34,9 @@ export interface CategoriesResponse {
 export interface FilterParams {
   category_id?: string
   storage_location?: 'fridge' | 'freezer' | 'pantry'
-  status?: 'all' | 'active' | 'expired' | 'expiring_soon'
+  /** Filtro sulla scadenza, derivata dalla data. Da non confondere con
+   *  `Food['status']`, che è l'esito scelto dall'utente. */
+  expiry?: 'all' | 'not_expired' | 'expiring_soon' | 'expired'
   search?: string
   sortBy?: 'expiry_date' | 'name' | 'created_at' | 'category_id'
   sortOrder?: 'asc' | 'desc'
@@ -93,20 +95,20 @@ export async function getFoods(filters?: FilterParams): Promise<FoodsResponse> {
       query = query.ilike('name', `%${filters.search.trim()}%`)
     }
 
-    // Apply status filter based on expiry date
-    if (filters?.status && filters.status !== 'all') {
+    // Apply expiry filter based on expiry date
+    if (filters?.expiry && filters.expiry !== 'all') {
       const today = new Date().toISOString().split('T')[0] // YYYY-MM-DD format
 
-      if (filters.status === 'expired') {
+      if (filters.expiry === 'expired') {
         // Expiry date is in the past
         query = query.lt('expiry_date', today)
-      } else if (filters.status === 'expiring_soon') {
+      } else if (filters.expiry === 'expiring_soon') {
         // Expiry date is within the "in scadenza" window (see EXPIRY_SOON_DAYS in @/lib/expiry)
         const soonCutoff = new Date()
         soonCutoff.setDate(soonCutoff.getDate() + EXPIRY_SOON_DAYS)
         const futureDate = soonCutoff.toISOString().split('T')[0]
         query = query.gte('expiry_date', today).lte('expiry_date', futureDate)
-      } else if (filters.status === 'active') {
+      } else if (filters.expiry === 'not_expired') {
         // Expiry date is in the future (not expired)
         query = query.gte('expiry_date', today)
       }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -24,6 +24,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../co
 import { Button } from '../components/ui/button'
 import type { Food, FilterParams } from '@/lib/foods'
 import { deriveDashboardData } from '@/lib/foodFilters'
+import { parseFilterParams, buildSearchParams } from '@/lib/foodFilterParams'
 import { cn } from '@/lib/utils'
 
 /**
@@ -68,17 +69,9 @@ export function DashboardPage() {
   // View mode from URL params
   const viewMode = (searchParams.get('view') as 'list' | 'calendar') || 'list'
 
-  // Parse filters from URL query params
-  const filters = useMemo<FilterParams>(() => {
-    return {
-      category_id: searchParams.get('category') || undefined,
-      storage_location: (searchParams.get('storage') as FilterParams['storage_location']) || undefined,
-      status: (searchParams.get('status') as FilterParams['status']) || 'all',
-      search: searchParams.get('search') || undefined,
-      sortBy: (searchParams.get('sortBy') as FilterParams['sortBy']) || 'expiry_date',
-      sortOrder: (searchParams.get('sortOrder') as FilterParams['sortOrder']) || 'asc',
-    }
-  }, [searchParams])
+  // Filtri letti dall'URL: la mappatura, e con essa la retrocompatibilità del
+  // vecchio `?status=`, vive in @/lib/foodFilterParams.
+  const filters = useMemo<FilterParams>(() => parseFilterParams(searchParams), [searchParams])
 
   // Debounce search to avoid excessive API calls
   const debouncedSearch = useDebounce(filters.search, 300)
@@ -119,7 +112,7 @@ export function DashboardPage() {
     let count = 0
     if (filters.category_id) count++
     if (filters.storage_location) count++
-    if (filters.status && filters.status !== 'all') count++
+    if (filters.expiry && filters.expiry !== 'all') count++
     if (filters.search) count++
     // Don't count sort as active filter since it always has a value
     return count
@@ -127,16 +120,7 @@ export function DashboardPage() {
 
   // Handlers for filter changes
   const handleFiltersChange = (newFilters: FilterParams) => {
-    const params = new URLSearchParams()
-
-    if (newFilters.category_id) params.set('category', newFilters.category_id)
-    if (newFilters.storage_location) params.set('storage', newFilters.storage_location)
-    if (newFilters.status && newFilters.status !== 'all') params.set('status', newFilters.status)
-    if (newFilters.search) params.set('search', newFilters.search)
-    if (newFilters.sortBy) params.set('sortBy', newFilters.sortBy)
-    if (newFilters.sortOrder) params.set('sortOrder', newFilters.sortOrder)
-
-    setSearchParams(params)
+    setSearchParams(buildSearchParams(newFilters))
   }
 
   const handleClearFilters = () => {
@@ -154,16 +138,10 @@ export function DashboardPage() {
   }
 
   // Quick filter handlers for stats cards
-  const handleQuickFilter = (status: 'all' | 'expiring_soon' | 'expired') => {
-    if (status === 'all') {
-      // Clear all filters to show everything
-      setSearchParams({})
-    } else {
-      // Apply status filter
-      const params = new URLSearchParams()
-      params.set('status', status)
-      setSearchParams(params)
-    }
+  const handleQuickFilter = (expiry: 'all' | 'expiring_soon' | 'expired') => {
+    // Si riparte da un URL nuovo: la card azzera gli altri filtri. `all` non
+    // viene scritto, così l'URL torna pulito.
+    setSearchParams(buildSearchParams({ expiry }))
     // Scroll to foods section on mobile
     window.scrollTo({ top: 400, behavior: 'smooth' })
   }
@@ -202,7 +180,7 @@ export function DashboardPage() {
       </div>
 
       {/* Quick Stats - Compact Mobile Grid */}
-      <DashboardStats stats={stats} currentStatus={filters.status} onQuickFilter={handleQuickFilter} />
+      <DashboardStats stats={stats} currentExpiry={filters.expiry} onQuickFilter={handleQuickFilter} />
 
       {/* Notification Prompt */}
       <NotificationPrompt foodCount={stats.total} />


### PR DESCRIPTION
## Cosa cambia

- **Il filtro della dashboard non si chiama più «stato» ma «scadenza».** Sulla tabella `foods` convivono due assi indipendenti: `deleted_at` («lo traccio ancora?») e `status` («com'è finita?», con i valori `active`/`consumed`/`expired`/`wasted`). Il filtro non ha mai letto la colonna `status` — confronta `expiry_date` con la data di oggi — ma ne portava il nome, facendo sembrare collegate due cose che non lo sono. `FilterParams.status` diventa `FilterParams.expiry`, con i valori `all | not_expired | expiring_soon | expired`.
- **C'è un cambiamento visibile all'utente**, in una PR per il resto invisibile: l'etichetta del gruppo passa da «Stato» a «Scadenza» e l'opzione «✅ Attivi» diventa «✅ Non scaduti». Non è cosmesi ed è deliberatamente qui e non in una PR separata: quell'opzione ha sempre filtrato per «non scaduto», e «Attivi» è la metà visibile della stessa ambiguità che questa PR rimuove. Separarla lascerebbe per un po' un'etichetta che contraddice il codice.
- **I link già salvati e condivisi continuano a funzionare.** Il vecchio parametro `?status=` resta accettato in lettura, e `status=active` viene tradotto in `expiry=not_expired`: si conserva il significato, non la parola. In scrittura l'URL usa solo il nome nuovo. Se ci sono entrambi, vince il nuovo.
- **Nuovo modulo `src/lib/foodFilterParams.ts`** (`parseFilterParams` / `buildSearchParams`), estratto da un `useMemo` di `DashboardPage`. Il motivo dell'estrazione è la retrocompatibilità di cui sopra: è una promessa verso link che stanno fuori dall'app, e va provata senza dover montare l'intera dashboard per verificare una traduzione di stringhe.

### Una cosa che non è puro refactor

La mappatura estratta **valida i parametri contro il vocabolario**, dove la vecchia logica inline faceva un cast e si fidava dell'URL. Conseguenza reale: `?storage=banana` finiva così com'era nel confronto con `food.storage_location` e **non lasciava passare nessun alimento**, svuotando la lista. Ora ogni parametro non riconosciuto torna al proprio default. Per `sortBy` e `sortOrder` il valore non validato era innocuo a valle (`a[sortBy] ?? ''` collassava a un confronto nullo), ma passava comunque.

È un miglioramento, ma non è «nessun cambio di comportamento», quindi è dichiarato qui, nel CHANGELOG sotto `Fixed`, e coperto da test.

### Una collisione che resta, da conoscere

Dopo questa rinomina convivono due `expired`:

- `expiry: 'expired'` — filtro, **derivato** da `expiry_date`
- `status: 'expired'` — valore **memorizzato** nell'enum del ciclo di vita

Vale la pena dirlo esplicito: `expired` sull'asse `status` è un intruso. `consumed` e `wasted` sono decisioni prese dall'utente, `expired` è ricavabile dalla data e non richiede che nessuno lo dichiari. **Da non usare in flussi nuovi.** Il modello dei due assi è documentato in [E-Lop/entro-family#5](https://github.com/E-Lop/entro-family/pull/5), `core/food-lifecycle.md`.

### Copertura

Il nuovo modulo ha 14 test: legge `?expiry=`, accetta ancora `?status=`, traduce `status=active` → `not_expired`, il nuovo vince sul vecchio, scarta i valori fuori vocabolario (`expiry`, `storage`, `sortBy`, `sortOrder`), scrive solo `expiry` e mai `status`, omette il filtro quando vale `all`, scrive solo i filtri che riceve, e il giro completo scrivi-e-rileggi. Due test nuovi su `FoodFilters` pinnano le etichette e la chiave emessa. I test esistenti di `foodFilters` e `DashboardStats` erano cascati sulla rinomina, che è la rete di sicurezza che un refactor deve avere.

## Verifiche

- [x] `npm run lint` — 0 errori, 5 warning `react-refresh/only-export-components` preesistenti e invariati
- [x] `npm run typecheck` — pulito
- [x] `npm test` — 255 test su 45 file, tutti verdi
- [x] `npm run build` — ok

## Database e sicurezza

- [x] Nessuna modifica database
- [ ] Migration additive con RLS e GRANT espliciti
- [ ] Autorizzazione e azioni distruttive coperte da test o smoke test

## UI/mobile

- [ ] Nessuna modifica UI
- [ ] Verificata in viewport mobile
- [x] Testi e documentazione aggiornati se cambia il comportamento utente

> **Nota sulla verifica mobile:** non spuntata perché non l'ho eseguita. Il cambiamento visibile è testuale (due etichette dentro una `<select>` già esistente), non tocca layout né geometria, ed è coperto da test di componente. La suite e2e raggiunge la dashboard creando utenti reali su Supabase, quindi non l'ho lanciata di mia iniziativa. Se vuoi la conferma visiva, si fa in un passaggio.
