### PR TITLE
fix(auth): il logout pulisce lo storage anche se Supabase rifiuta (v1.10.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.10.6] - 2026-08-11
+
+### Security
+- Il logout pulisce lo storage anche quando Supabase rifiuta `signOut()`. La pulizia stava dentro il `try`, dopo il `throw` che segnalava l'errore, quindi non veniva mai eseguita: con una sessione già scaduta lato server l'utente premeva «esci» e i token `sb-*` restavano in `localStorage`, leggibili da chiunque aprisse i devtools. Su un browser condiviso — computer di famiglia, postazione in ufficio, portatile prestato — è la differenza fra un logout e un logout apparente. La pulizia è ora fuori dal percorso d'errore, e a sua volta protetta perché `localStorage` solleva quando il browser blocca lo storage: nessun wrapper di `src/lib/auth.ts` deve mai sollevare. L'errore riportato al chiamante resta quello di Supabase, che è la causa. (#78)
+
 ## [1.10.5] - 2026-08-11
 
 ### Changed
@@ -491,7 +496,8 @@ Lancio pubblico di Entro su LinkedIn.
 - Sistema di autenticazione Supabase completo
 - CRUD completo gestione alimenti con React Query
 
-[Unreleased]: https://github.com/E-Lop/entro/compare/v1.10.5...HEAD
+[Unreleased]: https://github.com/E-Lop/entro/compare/v1.10.6...HEAD
+[1.10.6]: https://github.com/E-Lop/entro/compare/v1.10.5...v1.10.6
 [1.10.5]: https://github.com/E-Lop/entro/compare/v1.10.4...v1.10.5
 [1.10.4]: https://github.com/E-Lop/entro/compare/v1.10.3...v1.10.4
 [1.10.3]: https://github.com/E-Lop/entro/compare/v1.10.2...v1.10.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.10.5",
+      "version": "1.10.6",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.10.5",
+  "version": "1.10.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+/**
+ * `signOut` — la pulizia dello storage non deve dipendere dall'esito di Supabase.
+ *
+ * Il caso vero non è il logout che riesce: è quello in cui la sessione è già
+ * scaduta lato server, Supabase rifiuta la richiesta, e i token restano nel
+ * browser. Su una macchina condivisa quei token sono leggibili da chiunque
+ * apra i devtools, e al ricaricamento il client può ricostruirci sopra una
+ * sessione.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockSignOut, mockUnsubscribeFromPush, mockClearPersistedCache } = vi.hoisted(() => ({
+  mockSignOut: vi.fn(),
+  mockUnsubscribeFromPush: vi.fn(),
+  mockClearPersistedCache: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { auth: { signOut: mockSignOut } },
+}))
+
+vi.mock('@/lib/pushNotifications', () => ({
+  unsubscribeFromPush: mockUnsubscribeFromPush,
+}))
+
+vi.mock('@/lib/queryPersister', () => ({
+  clearPersistedCache: mockClearPersistedCache,
+}))
+
+import { signOut } from '@/lib/auth'
+
+/** Le chiavi che un utente loggato si trova in `localStorage`. */
+function seedSession(): void {
+  localStorage.setItem('sb-rmbmmwcxtnanacxbkihc-auth-token', 'token-di-sessione')
+  localStorage.setItem('supabase.auth.token', 'token-legacy')
+  localStorage.setItem('show_welcome_toast', '1')
+  sessionStorage.setItem('user_initialized_abc', '1')
+  sessionStorage.setItem('explicit_auth', '123')
+  // Non è roba di auth: deve sopravvivere al logout.
+  localStorage.setItem('theme', 'dark')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  sessionStorage.clear()
+  mockUnsubscribeFromPush.mockResolvedValue(undefined)
+  mockClearPersistedCache.mockResolvedValue(undefined)
+  mockSignOut.mockResolvedValue({ error: null })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('signOut', () => {
+  it('pulisce lo storage quando Supabase accetta il logout', async () => {
+    seedSession()
+
+    const { error } = await signOut()
+
+    expect(error).toBeNull()
+    expect(localStorage.getItem('sb-rmbmmwcxtnanacxbkihc-auth-token')).toBeNull()
+    expect(localStorage.getItem('supabase.auth.token')).toBeNull()
+    expect(sessionStorage.getItem('user_initialized_abc')).toBeNull()
+  })
+
+  it('lascia intatto quello che non è di auth', async () => {
+    seedSession()
+
+    await signOut()
+
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('pulisce lo storage anche quando Supabase rifiuta il logout', async () => {
+    // Sessione già scaduta lato server: è il caso che lasciava i token nel
+    // browser mentre la UI riportava l'utente al login.
+    seedSession()
+    mockSignOut.mockResolvedValue({ error: { message: 'Session from session_id claim in JWT does not exist' } })
+
+    const { error } = await signOut()
+
+    expect(error?.message).toBe('Session from session_id claim in JWT does not exist')
+    expect(localStorage.getItem('sb-rmbmmwcxtnanacxbkihc-auth-token')).toBeNull()
+    expect(localStorage.getItem('supabase.auth.token')).toBeNull()
+    expect(sessionStorage.getItem('user_initialized_abc')).toBeNull()
+  })
+
+  it('pulisce lo storage anche quando la chiamata a Supabase solleva', async () => {
+    seedSession()
+    mockSignOut.mockRejectedValue(new Error('Network request failed'))
+
+    const { error } = await signOut()
+
+    expect(error?.message).toBe('Network request failed')
+    expect(localStorage.getItem('sb-rmbmmwcxtnanacxbkihc-auth-token')).toBeNull()
+  })
+
+  it('non solleva se la pulizia stessa fallisce: riporta l\'errore nella risposta', async () => {
+    // `localStorage` può sollevare quando il browser blocca lo storage
+    // (Safari con i cookie bloccati, contesti incorporati). Il contratto del
+    // modulo è che nessun wrapper sollevi mai: chi chiama legge `error`.
+    seedSession()
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('Storage disabilitato')
+    })
+
+    const { error } = await signOut()
+
+    expect(error?.message).toBe('Storage disabilitato')
+  })
+
+  it('quando falliscono entrambi riporta l\'errore di Supabase, che è la causa', async () => {
+    seedSession()
+    mockSignOut.mockResolvedValue({ error: { message: 'Session non trovata' } })
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('Storage disabilitato')
+    })
+
+    const { error } = await signOut()
+
+    expect(error?.message).toBe('Session non trovata')
+  })
+
+  it('non lascia che un fallimento della disiscrizione push blocchi la pulizia', async () => {
+    seedSession()
+    mockUnsubscribeFromPush.mockRejectedValue(new Error('Push endpoint irraggiungibile'))
+
+    const { error } = await signOut()
+
+    expect(error).toBeNull()
+    expect(localStorage.getItem('sb-rmbmmwcxtnanacxbkihc-auth-token')).toBeNull()
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -128,24 +128,35 @@ export async function signIn(
  * Selectively clears auth-related storage while preserving app settings.
  */
 export async function signOut(): Promise<{ error: Error | null }> {
-  try {
-    // Best-effort push cleanup -- errors are ignored since the user is signing out
-    await unsubscribeFromPush().catch(() => {})
+  // Best-effort push cleanup -- errors are ignored since the user is signing out
+  await unsubscribeFromPush().catch(() => {})
 
+  let failure: Error | null = null
+
+  try {
     const { error } = await supabase.auth.signOut()
 
     if (error) {
-      throw new Error(error.message)
+      failure = new Error(error.message)
     }
-
-    clearAuthStorage()
-
-    return { error: null }
   } catch (error) {
-    return {
-      error: error instanceof Error ? error : new Error('Errore durante il logout'),
-    }
+    failure = error instanceof Error ? error : new Error('Errore durante il logout')
   }
+
+  // La pulizia non dipende dall'esito di Supabase. Il caso tipico è la sessione
+  // già scaduta lato server: la richiesta viene rifiutata, ma i token devono
+  // sparire dal browser lo stesso, altrimenti restano leggibili in localStorage
+  // su una macchina condivisa e il client può ricostruirci sopra una sessione.
+  // Guardata a sua volta perché accedere a `localStorage` solleva quando il
+  // browser blocca lo storage, e nessun wrapper di questo modulo deve sollevare.
+  try {
+    clearAuthStorage()
+  } catch (error) {
+    failure ??= error instanceof Error ? error : new Error('Errore durante la pulizia della sessione')
+  }
+
+  // L'errore di Supabase ha la precedenza: è la causa, la pulizia è la conseguenza.
+  return { error: failure }
 }
 
 /**


### PR DESCRIPTION
Closes #78.

## Cosa cambia

`clearAuthStorage()` stava **dentro** il `try`, sulla riga dopo il `throw` che segnalava l'errore di Supabase, quindi non veniva mai eseguita. Con una sessione già scaduta lato server — il caso tipico, e anche quello in cui è più probabile che un utente prema «esci», visto che una sessione morta è spesso il motivo per cui ha deciso di uscire — i token `sb-*` restavano in `localStorage`.

Su un browser condiviso è la differenza fra un logout e un logout apparente: quei token sono leggibili da chiunque apra i devtools, e al ricaricamento il client può ricostruirci sopra una sessione.

La pulizia è ora fuori dal percorso d'errore.

### Due dettagli che non sono cosmetici

**La pulizia è guardata a sua volta.** La issue suggeriva che, essendo `clearAuthStorage()` sincrona nella PWA (a differenza di entro-mobile, dove passa da AsyncStorage e keychain), bastasse spostare la chiamata fuori dal `try`. Non basta: *sincrona* non vuol dire *che non solleva*. Accedere a `localStorage` solleva quando il browser blocca lo storage — Safari con i cookie bloccati, contesti incorporati — e il contratto di `src/lib/auth.ts` è che nessun wrapper sollevi mai: ogni funzione riporta l'errore nella forma di ritorno. Senza il secondo `try`, `signOut` avrebbe potuto sollevare in faccia a `useAuth`, che non se lo aspetta. C'è un test che lo pinna.

**L'errore di Supabase ha la precedenza** su quello della pulizia (`failure ??=`). È la causa; il fallimento della pulizia è la conseguenza, e mostrarlo al posto dell'originale nasconderebbe il motivo vero.

## Copertura

Sette test, i primi due scritti rossi contro il codice attuale:

- la pulizia avviene quando `supabase.auth.signOut()` **ritorna** errore 🔴
- la pulizia avviene quando la chiamata **solleva** 🔴
- percorso felice: pulizia e `error: null`
- quello che non è di auth (`theme`) sopravvive al logout
- un fallimento della pulizia torna nella risposta invece di essere sollevato
- quando falliscono entrambi viene riportato l'errore di Supabase
- un fallimento della disiscrizione push non blocca la pulizia

## Quello che questa PR NON risolve — vedi #81

Il fix toglie i token dallo storage, ma **non porta l'utente fuori dall'app**. `AppLayout.handleLogout` naviga a `/login` solo su `result.success`, quindi sul percorso d'errore l'utente vede un toast rosso e resta sulla dashboard, che continua a mostrare i suoi alimenti dalla cache React Query, finché non ricarica la pagina.

L'obiettivo di sicurezza della #78 è comunque centrato — i token a riposo spariscono, che è ciò che protegge il prossimo che usa quel browser. Quello che resta è un buco di coerenza nel layer di presentazione, in un altro file. L'ho aperto come **#81** invece di allargare questa PR, così resta tracciabile riga per riga.

## Nota sul merge

Questa PR prenota la **1.10.6** dando per scontato che #80 (1.10.5) entri prima. Entrambe toccano la cima del `CHANGELOG.md` e `package.json`: se inverti l'ordine di merge, la seconda va rebasata e le versioni scambiate. È inerente alla convenzione «la PR di feature porta il rilascio» con due PR in volo.

## Verifiche

- [x] `npm run lint` — 0 errori, 5 warning `react-refresh/only-export-components` preesistenti e invariati
- [x] `npm run typecheck` — pulito
- [x] `npm test` — 247 test su 45 file, tutti verdi (240/44 prima di questo branch)
- [x] `npm run build` — ok

## Database e sicurezza

- [x] Nessuna modifica database
- [ ] Migration additive con RLS e GRANT espliciti
- [x] Autorizzazione e azioni distruttive coperte da test o smoke test

## UI/mobile

- [x] Nessuna modifica UI
- [ ] Verificata in viewport mobile
- [ ] Testi e documentazione aggiornati se cambia il comportamento utente

> **Riproduzione manuale non eseguita.** I passi della issue (revocare la sessione da Supabase Studio, poi premere «esci») richiedono di toccare il progetto di produzione, dove ci sono utenti reali. Il difetto e il fix sono provati dai test con `supabase.auth.signOut()` che ritorna errore. Se vuoi la conferma end-to-end, si fa — ma va deciso su quale ambiente.
