### PR TITLE
fix(security): nessun token né codice invito nei log (v1.10.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.10.7] - 2026-08-11
+
+### Security
+- I log dei percorsi auth non possono più contenere token di sessione né codici invito. Nessuna riga stampava un segreto di proposito: uscivano di rimbalzo, perché `console.error('contesto:', error)` stampa anche le **proprietà** dell'errore, e i client Supabase ci attaccano i dati della risposta — inclusa la sessione che stavano tentando di rinnovare. Nuovo modulo `src/lib/safeLog.ts`: `logError`/`logWarn` stampano il solo messaggio, ripulito dalle stringhe con la forma di un JWT, applicati in `auth.ts`, `authStore.ts`, `useRealtimeFoods.ts` e `SignUpPage.tsx`. Per il punto dell'invito non basta redigere e il messaggio del server non viene stampato affatto: `register_pending_invite` riceve il codice fra i parametri, quindi è il messaggio stesso a poterlo contenere. La PWA non ha Sentry — quei log restavano nella console del browser, non in un servizio esterno — ma erano comunque visibili a chiunque aprisse i devtools, su una macchina condivisa o durante una condivisione schermo. (#79)
+- Ripulito anche `src/lib/invites.ts`, che non era nell'elenco della issue e rendeva il resto aggirabile: `registerPendingInvite` stampava l'errore della RPC un frame sotto il punto già sistemato in `SignUpPage`, quindi il codice invito sarebbe finito in console lo stesso. Lì, come nel chiamante, il messaggio del server non viene stampato affatto; gli altri tredici punti del modulo passano da `logError`.
+- Anche `VerifyEmailPage` passa da `logError`: chiama `supabase.auth.getUser()` direttamente e stampava l'errore grezzo, quindi era un percorso auth a tutti gli effetti pur non comparendo nell'elenco della issue.
+- L'avviso di sicurezza sull'auto-login inatteso non logga più l'URL completo, ma solo origine e percorso. Era il punto più esposto e non era nell'elenco della issue: stampava `window.location.href` **proprio quando sospettava che l'URL contenesse un token di auth**, che è lo scenario descritto dall'avviso stesso. Query e frammento vengono scartati interi invece che ripuliti, perché il `refresh_token` di Supabase è opaco e nessun pattern lo intercetterebbe.
+
 ## [1.10.6] - 2026-08-11
 
 ### Security
@@ -496,7 +504,8 @@ Lancio pubblico di Entro su LinkedIn.
 - Sistema di autenticazione Supabase completo
 - CRUD completo gestione alimenti con React Query
 
-[Unreleased]: https://github.com/E-Lop/entro/compare/v1.10.6...HEAD
+[Unreleased]: https://github.com/E-Lop/entro/compare/v1.10.7...HEAD
+[1.10.7]: https://github.com/E-Lop/entro/compare/v1.10.6...v1.10.7
 [1.10.6]: https://github.com/E-Lop/entro/compare/v1.10.5...v1.10.6
 [1.10.5]: https://github.com/E-Lop/entro/compare/v1.10.4...v1.10.5
 [1.10.4]: https://github.com/E-Lop/entro/compare/v1.10.3...v1.10.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.10.6",
+      "version": "1.10.7",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.10.6",
+  "version": "1.10.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/useRealtimeFoods.ts
+++ b/src/hooks/useRealtimeFoods.ts
@@ -12,6 +12,7 @@ import type { RealtimeChannel } from '@supabase/supabase-js';
 import { toast } from 'sonner';
 import { supabase } from '../lib/supabase';
 import { getUserList } from '../lib/invites';
+import { logError, logWarn } from '../lib/safeLog';
 import {
   handleFoodRealtimeEvent,
   mutationTracker,
@@ -76,7 +77,7 @@ export function useRealtimeFoods() {
         if (!mounted) return;
 
         if (listError || !list) {
-          console.warn('[useRealtimeFoods] No list found for user:', listError);
+          logWarn('[useRealtimeFoods] No list found for user:', listError);
           setError('Nessuna lista trovata per questo utente');
           return;
         }
@@ -179,7 +180,7 @@ export function useRealtimeFoods() {
           });
       } catch (err) {
         if (!mounted) return;
-        console.error('[useRealtimeFoods] Error setting up subscription:', err);
+        logError('[useRealtimeFoods] Error setting up subscription:', err);
         setError('Errore nella configurazione del realtime');
       }
     }
@@ -234,7 +235,7 @@ export function useRealtimeFoods() {
             return;
           }
         } catch (err) {
-          console.error('[Realtime] Error refreshing session:', err);
+          logError('[Realtime] Error refreshing session:', err);
           return;
         }
 

--- a/src/lib/__tests__/noSecretsInLogs.test.ts
+++ b/src/lib/__tests__/noSecretsInLogs.test.ts
@@ -22,7 +22,8 @@ const REFRESH_TOKEN = 'eyJyZWZyZXNoIjoidG9rZW4ifQ.eyJleHAiOjk5OTk5OTk5fQ.Kx8sPqW
 // far fallire niente. Resta nell'elenco perché il giorno in cui si aggiunge un
 // flusso che ne maneggia una, il controllo c'è già.
 const PASSWORD = 'PasswordSegretissima!2026'
-const INVITE_CODE = 'ABCD1234'
+/** Sei caratteri alfanumerici, come i codici veri (`ABC123`). */
+const INVITE_CODE = 'ZK7Q2M'
 
 const SENTINELS = [TOKEN, REFRESH_TOKEN, PASSWORD, INVITE_CODE]
 

--- a/src/lib/__tests__/noSecretsInLogs.test.ts
+++ b/src/lib/__tests__/noSecretsInLogs.test.ts
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+/**
+ * Nessun segreto nella console.
+ *
+ * Il controllo che questo test sostituisce — rileggere le chiamate a
+ * `console.*` a occhio — è esattamente quello che aveva lasciato passare il
+ * difetto: quasi nessun punto stampa un segreto direttamente, lo stampa di
+ * rimbalzo. `console.error('contesto:', error)` stampa anche le *proprietà*
+ * dell'errore, e i client Supabase ci attaccano i dati della risposta,
+ * inclusa la sessione che stavano tentando di rinnovare.
+ *
+ * Quindi qui non si legge il codice: si eseguono i flussi con valori
+ * sentinella e si guarda cosa esce.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/** Un JWT nella forma reale: tre segmenti base64url, il primo apre con `eyJ`. */
+const TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+const REFRESH_TOKEN = 'eyJyZWZyZXNoIjoidG9rZW4ifQ.eyJleHAiOjk5OTk5OTk5fQ.Kx8sPqWvT2mNbYcR4hL7dGfZ1aE0uJ3iO5nQ'
+// Nessun flusso qui sotto passa una password: oggi questa sentinella non può
+// far fallire niente. Resta nell'elenco perché il giorno in cui si aggiunge un
+// flusso che ne maneggia una, il controllo c'è già.
+const PASSWORD = 'PasswordSegretissima!2026'
+const INVITE_CODE = 'ABCD1234'
+
+const SENTINELS = [TOKEN, REFRESH_TOKEN, PASSWORD, INVITE_CODE]
+
+const { mockAuth, mockRpc } = vi.hoisted(() => ({
+  mockAuth: {
+    getUser: vi.fn(),
+    getSession: vi.fn(),
+  },
+  mockRpc: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({ supabase: { auth: mockAuth, rpc: mockRpc } }))
+
+import { getCurrentUser, getSession } from '@/lib/auth'
+import { registerPendingInvite } from '@/lib/invites'
+import { redactSecrets, redactUrl, logError } from '@/lib/safeLog'
+
+const METHODS = ['log', 'info', 'warn', 'error', 'debug'] as const
+
+let captured: string[]
+
+/**
+ * Serializza come farebbe una console vera: di un `Error` mostra il messaggio
+ * *e* le proprietà, che è il punto in cui i segreti escono di rimbalzo.
+ */
+function serialize(value: unknown): string {
+  if (value instanceof Error) {
+    return `${value.message} ${JSON.stringify({ ...value })}`
+  }
+  if (typeof value === 'object' && value !== null) {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+beforeEach(() => {
+  captured = []
+  for (const method of METHODS) {
+    vi.spyOn(console, method).mockImplementation((...args: unknown[]) => {
+      captured.push(args.map(serialize).join(' '))
+    })
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/** Tutto quello che è finito in console, in un'unica stringa. */
+function output(): string {
+  return captured.join('\n')
+}
+
+function expectNoSentinels(): void {
+  const logged = output()
+  for (const sentinel of SENTINELS) {
+    expect(logged).not.toContain(sentinel)
+  }
+}
+
+/** Un errore Supabase come arriva davvero: con la sessione appesa addosso. */
+function supabaseErrorWithSession(message: string): Error {
+  return Object.assign(new Error(message), {
+    status: 400,
+    session: { access_token: TOKEN, refresh_token: REFRESH_TOKEN },
+  })
+}
+
+describe('redactSecrets', () => {
+  it('toglie un JWT da una stringa', () => {
+    expect(redactSecrets(`token=${TOKEN}`)).not.toContain(TOKEN)
+  })
+
+  it('lascia in piedi gli host, che non sono segreti', () => {
+    // Un pattern «tre segmenti separati da punto» senza il prefisso `eyJ`
+    // colpirebbe anche questo, e un log che cancella a caso smette di servire
+    // a diagnosticare.
+    const host = 'rmbmmwcxtnanacxbkihc.functions.supabase.co'
+    expect(redactSecrets(`fetch fallita su ${host}`)).toContain(host)
+  })
+
+  it('lascia in piedi un dominio normale', () => {
+    expect(redactSecrets('errore su entroapp.it')).toContain('entroapp.it')
+  })
+
+  it('toglie più token dalla stessa stringa', () => {
+    const redatto = redactSecrets(`a=${TOKEN} b=${REFRESH_TOKEN}`)
+    expect(redatto).not.toContain(TOKEN)
+    expect(redatto).not.toContain(REFRESH_TOKEN)
+  })
+
+  it('non tocca una stringa senza segreti', () => {
+    const message = 'Session from session_id claim in JWT does not exist'
+    expect(redactSecrets(message)).toBe(message)
+  })
+})
+
+describe('redactUrl', () => {
+  it('butta il frammento, dove Supabase mette i parametri di sessione', () => {
+    const href = `https://entroapp.it/dashboard#access_token=${TOKEN}&refresh_token=opaco-non-jwt&type=magiclink`
+
+    const redatto = redactUrl(href)
+
+    expect(redatto).toBe('https://entroapp.it/dashboard')
+    expect(redatto).not.toContain(TOKEN)
+    // Il refresh token di Supabase è opaco: non ha la forma di un JWT e
+    // nessun pattern lo intercetterebbe. Per questo si butta tutto il
+    // frammento invece di ripulirlo.
+    expect(redatto).not.toContain('opaco-non-jwt')
+  })
+
+  it('butta anche la query', () => {
+    expect(redactUrl(`https://entroapp.it/signup?code=${INVITE_CODE}`)).toBe(
+      'https://entroapp.it/signup'
+    )
+  })
+
+  it('tiene origine e percorso, che sono il motivo per cui si logga l\'URL', () => {
+    const href = 'https://entroapp.it/reset-password'
+    expect(redactUrl(href)).toBe(href)
+  })
+
+  it('non solleva su un URL malformato', () => {
+    expect(redactUrl('non-un-url')).toBe('[url non valido]')
+  })
+})
+
+describe('logError', () => {
+  it('non stampa le proprietà dell\'errore, dove si nasconde la sessione', () => {
+    logError('[test] contesto:', supabaseErrorWithSession('Token refresh fallito'))
+
+    expect(output()).toContain('Token refresh fallito')
+    expectNoSentinels()
+  })
+
+  it('redige un token che sta nel messaggio stesso', () => {
+    logError('[test] contesto:', new Error(`Refresh fallito per ${TOKEN}`))
+    expectNoSentinels()
+  })
+
+  it('regge un valore che non è un Error', () => {
+    logError('[test] contesto:', { access_token: TOKEN })
+    expectNoSentinels()
+  })
+
+  it('mantiene il contesto, che è il motivo per cui si logga', () => {
+    logError('[authStore] Errore:', new Error('qualcosa'))
+    expect(output()).toContain('[authStore] Errore:')
+  })
+})
+
+describe('flussi auth — niente segreti in console', () => {
+  it('getCurrentUser con errore che si porta dietro la sessione', async () => {
+    mockAuth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: supabaseErrorWithSession('Errore nel recupero utente'),
+    })
+
+    await getCurrentUser()
+
+    expectNoSentinels()
+  })
+
+  it('getCurrentUser quando la chiamata solleva', async () => {
+    mockAuth.getUser.mockRejectedValue(supabaseErrorWithSession('Boom'))
+
+    await getCurrentUser()
+
+    expectNoSentinels()
+  })
+
+  it('getSession con errore che si porta dietro la sessione', async () => {
+    // Qui il token deve stare anche nel *messaggio*: `getSession` rimpacchetta
+    // l'errore in un `new Error(error.message)`, quindi le proprietà si
+    // perdono per strada e un test che guardasse solo quelle passerebbe a
+    // vuoto, provando la protezione accidentale invece del redattore.
+    mockAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: supabaseErrorWithSession(`Refresh fallito per ${TOKEN}`),
+    })
+
+    await getSession()
+
+    expectNoSentinels()
+  })
+
+  it('getSession quando la chiamata solleva', async () => {
+    mockAuth.getSession.mockRejectedValue(supabaseErrorWithSession('Boom'))
+
+    await getSession()
+
+    expectNoSentinels()
+  })
+})
+
+describe('flusso invito — il codice non finisce in console', () => {
+  it('registerPendingInvite con un messaggio del server che contiene il codice', async () => {
+    // `register_pending_invite` riceve il codice fra i parametri: un
+    // `RAISE EXCEPTION` che lo interpola lo porta nel messaggio. Qui non
+    // basta redigere — il segreto *è* il messaggio — quindi il messaggio del
+    // server non va stampato affatto.
+    mockRpc.mockResolvedValue({
+      error: new Error(`invito ${INVITE_CODE} già utilizzato`),
+    })
+
+    await registerPendingInvite(INVITE_CODE, 'utente@example.com')
+
+    expectNoSentinels()
+  })
+
+  it('registerPendingInvite quando la chiamata solleva col codice nel messaggio', async () => {
+    mockRpc.mockRejectedValue(new Error(`invito ${INVITE_CODE} non valido`))
+
+    await registerPendingInvite(INVITE_CODE, 'utente@example.com')
+
+    expectNoSentinels()
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase'
 import { unsubscribeFromPush } from './pushNotifications'
 import { clearPersistedCache } from './queryPersister'
+import { logError } from './safeLog'
 import type { User, Session } from '@supabase/supabase-js'
 
 /**
@@ -177,7 +178,7 @@ export async function getCurrentUser(): Promise<User | null> {
 
     if (error) {
       if (!isSessionMissingError(error.message ?? '')) {
-        console.error('Error getting current user:', error)
+        logError('Error getting current user:', error)
       }
       return null
     }
@@ -186,7 +187,7 @@ export async function getCurrentUser(): Promise<User | null> {
   } catch (error) {
     const message = error instanceof Error ? error.message : ''
     if (!isSessionMissingError(message)) {
-      console.error('Error getting current user:', error)
+      logError('Error getting current user:', error)
     }
     return null
   }
@@ -201,7 +202,7 @@ export async function getSession(): Promise<Session | null> {
     if (error) throw new Error(error.message)
     return data.session
   } catch (error) {
-    console.error('Error getting session:', error)
+    logError('Error getting session:', error)
     return null
   }
 }

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { logError } from './safeLog'
 import type {
   CreateInviteResponse,
   ValidateInviteResponse,
@@ -111,7 +112,11 @@ export async function registerPendingInvite(
     })
 
     if (error) {
-      console.error('[registerPendingInvite] Error registering pending invite:', error)
+      // Il messaggio del server non viene stampato: `register_pending_invite`
+      // riceve il codice invito fra i parametri, quindi un `RAISE EXCEPTION`
+      // che lo interpola lo farebbe finire in console. Qui il segreto è il
+      // messaggio stesso, e redigerlo non basterebbe.
+      console.error('[registerPendingInvite] Error registering pending invite')
       throw error
     }
 
@@ -120,7 +125,7 @@ export async function registerPendingInvite(
       error: null,
     }
   } catch (error) {
-    console.error('[registerPendingInvite] Failed:', error)
+    console.error('[registerPendingInvite] Failed')
     return {
       success: false,
       error: error instanceof Error ? error : new Error('Unknown error'),
@@ -178,7 +183,7 @@ export async function acceptInviteByEmail(): Promise<AcceptInviteResponse> {
   try {
     const { data, error } = await supabase.rpc('accept_pending_invite_by_email')
     if (error) {
-      console.error('[acceptInviteByEmail] RPC error:', error)
+      logError('[acceptInviteByEmail] RPC error:', error)
       return { success: false, listId: null, error: new Error(error.message) }
     }
     const row = Array.isArray(data) ? data[0] : data
@@ -211,12 +216,7 @@ export async function getUserList(): Promise<ListResponse> {
       .maybeSingle()
 
     if (memberError) {
-      console.error('[getUserList] Error querying list_members:', {
-        code: memberError.code,
-        message: memberError.message,
-        details: memberError.details,
-        hint: memberError.hint,
-      })
+      logError('[getUserList] Error querying list_members:', memberError)
     }
 
     if (memberError || !memberData) {
@@ -232,7 +232,7 @@ export async function getUserList(): Promise<ListResponse> {
       .maybeSingle()
 
     if (listError) {
-      console.error('[getUserList] Error querying lists:', listError)
+      logError('[getUserList] Error querying lists:', listError)
     }
 
     if (listError || !listData) {
@@ -245,7 +245,7 @@ export async function getUserList(): Promise<ListResponse> {
       error: null,
     }
   } catch (error) {
-    console.error('[getUserList] Failed to get user list:', error)
+    logError('[getUserList] Failed to get user list:', error)
     return {
       list: null,
       error: error instanceof Error ? error : new Error('Unknown error'),
@@ -311,7 +311,7 @@ export async function createPersonalList(): Promise<{
       .single()
 
     if (error) {
-      console.error('[createPersonalList] Error calling create_personal_list():', error)
+      logError('[createPersonalList] Error calling create_personal_list():', error)
       throw new Error(error.message)
     }
 
@@ -325,7 +325,7 @@ export async function createPersonalList(): Promise<{
 
     // Check the result from the function
     if (!result.success) {
-      console.error('[createPersonalList] Function returned error:', result.error_message)
+      logError('[createPersonalList] Function returned error:', result.error_message)
       throw new Error(result.error_message || 'Failed to create personal list')
     }
 
@@ -335,7 +335,7 @@ export async function createPersonalList(): Promise<{
       error: null,
     }
   } catch (error) {
-    console.error('[createPersonalList] Failed to create personal list:', error)
+    logError('[createPersonalList] Failed to create personal list:', error)
     return {
       success: false,
       listId: null,
@@ -405,7 +405,7 @@ export async function leaveSharedList(): Promise<{ success: boolean; error: Erro
       .maybeSingle()
 
     if (currentMemberError) {
-      console.error('[leaveSharedList] Error getting current list:', currentMemberError)
+      logError('[leaveSharedList] Error getting current list:', currentMemberError)
       throw currentMemberError
     }
 
@@ -423,7 +423,7 @@ export async function leaveSharedList(): Promise<{ success: boolean; error: Erro
       .eq('list_id', currentListId)
 
     if (memberCountError) {
-      console.error('[leaveSharedList] Error counting members:', memberCountError)
+      logError('[leaveSharedList] Error counting members:', memberCountError)
       throw memberCountError
     }
 
@@ -440,19 +440,14 @@ export async function leaveSharedList(): Promise<{ success: boolean; error: Erro
       .eq('user_id', userId)
 
     if (removeError) {
-      console.error('[leaveSharedList] Error removing user from list:', {
-        error: removeError,
-        code: removeError.code,
-        message: removeError.message,
-        details: removeError.details,
-      })
+      logError('[leaveSharedList] Error removing user from list:', removeError)
       throw removeError
     }
 
     // Step 4: Create new personal list
     const createResult = await createPersonalList()
     if (!createResult.success) {
-      console.error('[leaveSharedList] Failed to create personal list:', createResult.error)
+      logError('[leaveSharedList] Failed to create personal list:', createResult.error)
       throw createResult.error || new Error('Failed to create personal list')
     }
 
@@ -461,7 +456,7 @@ export async function leaveSharedList(): Promise<{ success: boolean; error: Erro
       error: null,
     }
   } catch (error) {
-    console.error('[leaveSharedList] Leave list flow failed:', error)
+    logError('[leaveSharedList] Leave list flow failed:', error)
     return {
       success: false,
       error: error instanceof Error ? error : new Error('Unknown error'),

--- a/src/lib/safeLog.ts
+++ b/src/lib/safeLog.ts
@@ -1,0 +1,66 @@
+/**
+ * Log che non si porta dietro segreti.
+ *
+ * Il problema non è che qualcuno stampi un token di proposito: è che
+ * `console.error('contesto:', error)` stampa anche le **proprietà**
+ * dell'errore, e i client Supabase ci attaccano i dati della risposta —
+ * inclusa la sessione che stavano tentando di rinnovare. Passare l'oggetto
+ * alla console è il modo in cui i segreti escono di rimbalzo.
+ *
+ * Da qui passa un messaggio e basta, ripulito.
+ */
+
+/**
+ * Tre segmenti base64url separati da punto, col prefisso che ogni JWT ha per
+ * costruzione: il primo segmento codifica `{"alg"…`, che in base64url comincia
+ * sempre per `eyJ`.
+ *
+ * Il prefisso non è pedanteria. Senza, il pattern colpisce anche gli host a
+ * tre etichette e `<ref>.functions.supabase.co` finisce redatto: un log che
+ * cancella a caso smette di servire a diagnosticare, che è l'unico motivo per
+ * cui esiste.
+ */
+const JWT_PATTERN = /eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g
+
+/** Toglie da un testo le stringhe che hanno la forma di un JWT. */
+export function redactSecrets(text: string): string {
+  return text.replace(JWT_PATTERN, '[token rimosso]')
+}
+
+/**
+ * Un URL ridotto a quello che serve per capire *dove* si era: origine e
+ * percorso.
+ *
+ * Query e frammento vengono buttati interi invece che ripuliti, perché è lì
+ * che Supabase mette i parametri di sessione dopo un magic link, e il
+ * `refresh_token` — a differenza dell'access token — non è un JWT: è opaco,
+ * non ha una forma riconoscibile, e nessun pattern lo intercetterebbe.
+ */
+export function redactUrl(href: string): string {
+  try {
+    const url = new URL(href)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return '[url non valido]'
+  }
+}
+
+/** Il messaggio di un errore, qualunque cosa sia arrivata. */
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Logga un errore mostrando il solo messaggio, ripulito.
+ *
+ * Le proprietà dell'errore non vengono stampate: è deliberato, ed è tutto il
+ * punto di questo modulo.
+ */
+export function logError(context: string, error: unknown): void {
+  console.error(context, redactSecrets(messageOf(error)))
+}
+
+/** Come `logError`, per le condizioni che non sono errori. */
+export function logWarn(context: string, error: unknown): void {
+  console.warn(context, redactSecrets(messageOf(error)))
+}

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -10,6 +10,7 @@ import { Footer } from '../components/layout/Footer'
 import { useAuth } from '../hooks/useAuth'
 import { useDocumentMeta } from '../hooks/useDocumentMeta'
 import { validateInvite, registerPendingInvite } from '../lib/invites'
+import { logError } from '../lib/safeLog'
 import { Loader2 } from 'lucide-react'
 
 function getSignUpDescription(
@@ -104,10 +105,14 @@ export function SignUpPage() {
     try {
       if (inviteCode && inviteValid && email) {
         // Register this email with the invite so it can be accepted after email confirmation
-        const { success, error } = await registerPendingInvite(inviteCode, email)
+        const { success } = await registerPendingInvite(inviteCode, email)
 
         if (!success) {
-          console.error('Failed to register pending invite:', error)
+          // Il messaggio del server non viene stampato: `register_pending_invite`
+          // riceve il codice invito fra i parametri, e un `RAISE EXCEPTION` che
+          // lo interpola lo farebbe finire in console. Qui non basta redigere,
+          // perché il segreto è il messaggio stesso.
+          console.error('Failed to register pending invite')
         }
       }
 
@@ -118,7 +123,7 @@ export function SignUpPage() {
         navigate('/verify-email')
       }
     } catch (error) {
-      console.error('Post-signup error:', error)
+      logError('Post-signup error:', error)
     }
   }
 

--- a/src/pages/VerifyEmailPage.tsx
+++ b/src/pages/VerifyEmailPage.tsx
@@ -7,6 +7,7 @@ import { Footer } from '../components/layout/Footer'
 import { useAuth } from '../hooks/useAuth'
 import { useDocumentMeta } from '../hooks/useDocumentMeta'
 import { supabase } from '../lib/supabase'
+import { logError } from '../lib/safeLog'
 import { Mail, CheckCircle2, Loader2 } from 'lucide-react'
 
 function getResendButtonContent(isResending: boolean, resendSuccess: boolean): ReactNode {
@@ -70,7 +71,7 @@ export function VerifyEmailPage() {
           return
         }
       } catch (error) {
-        console.error('Error getting user email:', error)
+        logError('Error getting user email:', error)
       }
 
       // If no email found anywhere, redirect to signup

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { User, Session } from '@supabase/supabase-js'
 import { onAuthStateChange, getSession, getCurrentUser } from '../lib/auth'
+import { logError, redactUrl } from '../lib/safeLog'
 import { acceptInviteByEmail, getUserList, createPersonalList } from '../lib/invites'
 import { queryClient } from '../lib/queryClient'
 import { notifyWelcomeToast } from '../lib/welcomeToast'
@@ -122,7 +123,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
             sessionStorage.setItem(processedKey, 'true')
             return
           } else if (error) {
-            console.error('[authStore] Failed to accept invite:', error.message)
+            logError('[authStore] Failed to accept invite:', error)
             // Don't return - try to create personal list as fallback
           }
 
@@ -133,12 +134,12 @@ export const useAuthStore = create<AuthStore>((set) => ({
             await refreshAuthenticatedData()
             sessionStorage.setItem(processedKey, 'true')
           } else {
-            console.error('[authStore] Failed to create personal list:', createError)
+            logError('[authStore] Failed to create personal list:', createError)
             // Mark as processed to prevent infinite retries
             sessionStorage.setItem(processedKey, 'true')
           }
         } catch (error) {
-          console.error('[authStore] Error initializing user:', error)
+          logError('[authStore] Error initializing user:', error)
           // Mark as processed to prevent infinite retries on persistent errors
           sessionStorage.setItem(processedKey, 'true')
         }
@@ -181,7 +182,9 @@ export const useAuthStore = create<AuthStore>((set) => ({
         if (isAutoLogin && !authorizedAutoLoginEvents.includes(event)) {
           console.warn('[authStore] ⚠️  SECURITY: Unexpected auto-login detected!', {
             event,
-            url: window.location.href,
+            // Origine e percorso, senza query né frammento: è proprio lì che
+            // starebbe il token che questo avviso sospetta.
+            url: redactUrl(window.location.href),
             email: user?.email,
             suggestion: 'This could be from a shared URL with auth token. User should logout if this was not intentional.',
           })
@@ -214,7 +217,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
 
       return unsubscribe
     } catch (error) {
-      console.error('Error initializing auth:', error)
+      logError('Error initializing auth:', error)
       set({
         user: null,
         session: null,


### PR DESCRIPTION
Closes #79.

## Cosa cambia

Nessuna riga stampava un segreto di proposito — è per questo che a occhio sembrava tutto a posto. Uscivano di rimbalzo: `console.error('contesto:', error)` stampa anche le **proprietà** dell'errore, e i client Supabase ci attaccano i dati della risposta, inclusa la sessione che stavano tentando di rinnovare.

Nuovo modulo `src/lib/safeLog.ts`. `logError`/`logWarn` stampano il solo messaggio, ripulito dalle stringhe con la forma di un JWT. Applicato in `auth.ts`, `authStore.ts`, `useRealtimeFoods.ts`, `SignUpPage.tsx` e `invites.ts`.

Il prefisso `eyJ` nel pattern non è pedanteria: senza, «tre segmenti separati da punto» colpisce anche gli host, e `<ref>.functions.supabase.co` finirebbe redatto. Un log che cancella a caso smette di servire a diagnosticare, che è l'unico motivo per cui esiste. C'è un test che lo pinna.

## Due punti che l'elenco della issue non conteneva

Li segnalo per primi perché uno dei due rendeva il resto aggirabile.

**1. `src/lib/invites.ts` — il fix su `SignUpPage` da solo non serviva a niente.** La issue chiedeva di togliere il messaggio del server in `SignUpPage.tsx:110`, perché `register_pending_invite` riceve il codice invito fra i parametri e un `RAISE EXCEPTION` che lo interpola lo porta nel messaggio. Fatto — ma `registerPendingInvite` in `invites.ts` stampava lo stesso errore **un frame più sotto**, sullo stesso flusso. Il codice invito sarebbe finito in console comunque.

Lì il messaggio del server non viene stampato affatto, come nel chiamante. Gli altri tredici punti del modulo passano da `logError`. È il modulo che sta sul percorso di login e onboarding — `authStore.checkAndAcceptInvite` chiama `getUserList`, `acceptInviteByEmail` e `createPersonalList` — quindi lasciarlo fuori avrebbe reso il resto della PR decorativo.

**2. `src/stores/authStore.ts:183` — l'avviso di sicurezza era il punto più esposto.** Stampava `window.location.href` **proprio quando sospetta che l'URL contenga un token di auth**, che è lo scenario che l'avviso stesso descrive (`This could be from a shared URL with auth token`). Era il candidato più probabile a stampare un token vero.

Qui non basta redigere: il `refresh_token` di Supabase non è un JWT, è opaco, non ha una forma riconoscibile e nessun pattern lo intercetterebbe. Quindi `redactUrl` tiene origine e percorso e **butta query e frammento interi**. Un redattore basato su pattern lì avrebbe dato l'illusione di aver ripulito.

## Il test

Non rilegge le chiamate a `console.*`: quello è esattamente il controllo che aveva lasciato passare il difetto. Esegue i flussi con valori sentinella (un JWT nella forma reale, un refresh token, un codice invito, una password), intercetta `console.log/info/warn/error/debug` con una serializzazione che — come farebbe una console vera — include le **proprietà** dell'`Error` oltre al messaggio, e asserisce che le sentinelle non compaiano.

Sei flussi, tutti scritti rossi contro il codice attuale:

- `getCurrentUser` con un errore che si porta dietro la sessione, e quando la chiamata solleva 🔴
- `getSession` negli stessi due casi 🔴
- `registerPendingInvite` con un messaggio del server che contiene il codice, e quando la chiamata solleva 🔴

Più undici test su `redactSecrets`/`redactUrl`/`logError`, fra cui quelli che provano che gli **host sopravvivono** e che il frammento di un magic link sparisce.

### Due note di onestà sui test

**Uno dei miei passava a vuoto e l'ho riscritto.** Il caso `getSession` con errore sembrava verde già prima del fix: `getSession` rimpacchetta in `new Error(error.message)`, quindi le proprietà si perdono per strada e il test provava una protezione accidentale invece del redattore. Ora il token sta anche nel messaggio, ed era rosso come gli altri.

**La sentinella `PASSWORD` oggi non può far fallire nulla**, perché nessun flusso sotto test ne maneggia una. L'ho lasciata nell'elenco con un commento che lo dice, così il giorno che si aggiunge un flusso il controllo c'è già — ma non conta come copertura.

## Quello che questa PR NON copre

Restano `console.error('…:', error)` fuori dai percorsi auth, stessa forma e rischio più basso: `src/lib/storage.ts` (6), `src/hooks/useBarcodeScanner.ts` (6), `src/lib/dataExport.ts` (3), `src/lib/pushNotifications.ts` (2), `src/hooks/useSignedUrl.ts`, `src/components/settings/DeleteAccountDialog.tsx:153`, `src/pages/VerifyEmailPage.tsx:73`. La issue delimitava lo scopo ai percorsi auth e non ho allargato oltre `invites.ts`, che invece era necessario.

**Niente impedisce meccanicamente il ritorno del difetto.** Una regola eslint `no-restricted-syntax` che vieti il secondo argomento a `console.error`/`console.warn` sotto `src/lib` e `src/stores` lo bloccherebbe alla radice, ma inciamperebbe su tutti i file qui sopra finché non sono convertiti. Va fatto dopo, in un colpo solo.

## Verifiche

- [x] `npm run lint` — 0 errori, 5 warning `react-refresh/only-export-components` preesistenti e invariati
- [x] `npm run typecheck` — pulito
- [x] `npm test` — 259 test su 45 file, tutti verdi (240/44 prima di questo branch)
- [x] `npm run build` — ok

## Database e sicurezza

- [x] Nessuna modifica database
- [ ] Migration additive con RLS e GRANT espliciti
- [x] Autorizzazione e azioni distruttive coperte da test o smoke test

## UI/mobile

- [x] Nessuna modifica UI
- [ ] Verificata in viewport mobile
- [ ] Testi e documentazione aggiornati se cambia il comportamento utente

## Nota sul merge

Prenota la **1.10.7**, dando per scontato l'ordine #80 (1.10.5) → #82 (1.10.6) → questa. Tutte e tre toccano la cima del `CHANGELOG.md` e `package.json`: se l'ordine cambia, le successive vanno rebasate e le versioni scambiate.
