### PR TITLE
feat(alimenti): l'eliminazione chiede com'è finita, e non distrugge il dato (v1.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 - **Eliminare un alimento non distrugge più la riga.** Era una `DELETE` vera, quindi registrare l'esito e poi eliminare avrebbe scritto un dato e subito dopo l'avrebbe buttato: la metrica anti-spreco non avrebbe trovato niente. Ora è una sola `UPDATE` che imposta `deleted_at`, azzera `image_url` e registra l'esito — atomica, senza stati intermedi, e offline **una sola voce in coda** invece di due che si possono separare. `getFoods` già filtrava su `deleted_at IS NULL`, quindi per chi usa l'app la lista si comporta esattamente come prima.
 - **L'immagine invece viene cancellata davvero**, da Storage o da IndexedDB se era ancora in coda di caricamento. È un blob pesante che non serve a nessuna metrica, e tenerlo farebbe crescere lo spazio occupato a ogni eliminazione. È l'unica parte irreversibile: la riga si può ripristinare, la foto no. Se la cancellazione fallisce l'alimento esce comunque dalla lista — l'utente ha chiesto quello, e un blob rimasto indietro è un problema di spazio, non un motivo per disobbedire.
 
+- La cancellazione dell'immagine, quando fallisce, logga tramite `logError` (introdotto dalla 1.10.7) invece che con un messaggio muto: il branch era partito prima che quel modulo esistesse.
+
 ### Removed
 - La funzione di eliminazione definitiva (`deleteFood`), rimasta senza chiamanti. Restava accanto a `softDeleteFood` come alternativa apparentemente equivalente, ed è esattamente il tipo di ambiguità che ha prodotto questa situazione: `softDeleteFood` e `useUpdateFoodStatus` esistevano da tempo e non erano mai state collegate a niente.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.11.0] - 2026-08-12
+
+### Added
+- **L'eliminazione di un alimento ora chiede com'è finita.** La conferma non domanda più «sei sicuro?» — una domanda che non produce nessun dato, visto che l'utente ha già deciso premendo Elimina — ma offre tre uscite: «L'ho consumato», «L'ho buttato», «Toglilo e basta». La terza resta deliberatamente **senza esito**, perché è l'errore di inserimento: sporcare la metrica anti-spreco con gli errori la renderebbe inutile quanto lasciarla vuota. È la stessa interazione di prima, chiesta diversamente.
+- **Un menu azioni sempre presente sulle card.** Il pulsante ⋮ apre Modifica ed Elimina alle larghezze da telefono. I pulsanti in fondo alla card sono `hidden sm:flex`, e `display: none` non è «nascosto visivamente»: toglie dall'albero di accessibilità. Sotto i 640px lo swipe era l'unica strada, ed è `aria-hidden` — quindi su telefono con uno screen reader **non esisteva alcun modo di modificare o eliminare un alimento**. Un gesto basato su percorso deve avere un'alternativa a puntatore singolo: WCAG 2.5.1 *Pointer Gestures*, livello A. Il menu è `sm:hidden`, complemento esatto del footer: una sola strada a ogni larghezza. Lo swipe resta invariato per chi lo usa.
+
+### Changed
+- **Eliminare un alimento non distrugge più la riga.** Era una `DELETE` vera, quindi registrare l'esito e poi eliminare avrebbe scritto un dato e subito dopo l'avrebbe buttato: la metrica anti-spreco non avrebbe trovato niente. Ora è una sola `UPDATE` che imposta `deleted_at`, azzera `image_url` e registra l'esito — atomica, senza stati intermedi, e offline **una sola voce in coda** invece di due che si possono separare. `getFoods` già filtrava su `deleted_at IS NULL`, quindi per chi usa l'app la lista si comporta esattamente come prima.
+- **L'immagine invece viene cancellata davvero**, da Storage o da IndexedDB se era ancora in coda di caricamento. È un blob pesante che non serve a nessuna metrica, e tenerlo farebbe crescere lo spazio occupato a ogni eliminazione. È l'unica parte irreversibile: la riga si può ripristinare, la foto no. Se la cancellazione fallisce l'alimento esce comunque dalla lista — l'utente ha chiesto quello, e un blob rimasto indietro è un problema di spazio, non un motivo per disobbedire.
+
+### Removed
+- La funzione di eliminazione definitiva (`deleteFood`), rimasta senza chiamanti. Restava accanto a `softDeleteFood` come alternativa apparentemente equivalente, ed è esattamente il tipo di ambiguità che ha prodotto questa situazione: `softDeleteFood` e `useUpdateFoodStatus` esistevano da tempo e non erano mai state collegate a niente.
+
 ## [1.10.7] - 2026-08-11
 
 ### Security
@@ -504,7 +517,8 @@ Lancio pubblico di Entro su LinkedIn.
 - Sistema di autenticazione Supabase completo
 - CRUD completo gestione alimenti con React Query
 
-[Unreleased]: https://github.com/E-Lop/entro/compare/v1.10.7...HEAD
+[Unreleased]: https://github.com/E-Lop/entro/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/E-Lop/entro/compare/v1.10.7...v1.11.0
 [1.10.7]: https://github.com/E-Lop/entro/compare/v1.10.6...v1.10.7
 [1.10.6]: https://github.com/E-Lop/entro/compare/v1.10.5...v1.10.6
 [1.10.5]: https://github.com/E-Lop/entro/compare/v1.10.4...v1.10.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.10.7",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.10.7",
+      "version": "1.11.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.10.7",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/foods/FoodCard.tsx
+++ b/src/components/foods/FoodCard.tsx
@@ -1,8 +1,14 @@
 import { format } from 'date-fns'
 import { it } from 'date-fns/locale'
-import { Calendar, Package, Trash2, Edit, MapPin, ImageIcon, Loader2 } from 'lucide-react'
+import { Calendar, Package, Trash2, Edit, MapPin, ImageIcon, Loader2, MoreVertical } from 'lucide-react'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../ui/card'
 import { Button } from '../ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
 import type { Food, Category } from '@/lib/foods'
 import type { FoodWithRealtimeMetadata, ExpiryStatus } from '@/types/food.types'
 import { getExpiryStatus, getDaysUntilExpiry } from '@/lib/expiry'
@@ -137,6 +143,51 @@ export function FoodCard({ food, category, onEdit, onDelete, showHintAnimation =
             >
               {badgeText}
             </div>
+
+            {/* Alternativa allo swipe sotto i 640px, dove il footer non c'è.
+                I pulsanti del footer sono `hidden sm:flex`, e `display: none`
+                non è «nascosto visivamente»: toglie dall'albero di
+                accessibilità. Sotto i 640px lo swipe di SwipeableCard era
+                l'unico modo di modificare o eliminare, ed è `aria-hidden`.
+                Un gesto basato su percorso deve avere un'alternativa a
+                puntatore singolo (WCAG 2.5.1 Pointer Gestures, livello A).
+
+                `sm:hidden` è il complemento esatto di `hidden sm:flex` sul
+                footer: sotto i 640px c'è questo menu, sopra ci sono i
+                pulsanti, mai entrambi e mai nessuno dei due. È un invariante
+                fragile — due classi in due punti diversi — quindi c'è un test
+                che lo tiene fermo. */}
+            {(onEdit || onDelete) && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-11 w-11 shrink-0 -mr-2 -mt-1 sm:hidden"
+                    aria-label={`Azioni per ${food.name}`}
+                  >
+                    <MoreVertical className="h-5 w-5" aria-hidden="true" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {onEdit && (
+                    <DropdownMenuItem onSelect={() => onEdit(food)} className="h-11">
+                      <Edit className="h-4 w-4 mr-2" aria-hidden="true" />
+                      Modifica
+                    </DropdownMenuItem>
+                  )}
+                  {onDelete && (
+                    <DropdownMenuItem
+                      onSelect={() => onDelete(food)}
+                      className="h-11 text-destructive focus:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" />
+                      Elimina
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         </CardHeader>
 

--- a/src/components/foods/FoodModals.tsx
+++ b/src/components/foods/FoodModals.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from 'react'
+import { Check, Trash2, X } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -15,7 +16,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../ui/alert-dialog'
-import type { Food } from '@/lib/foods'
+import type { Food, FoodOutcome } from '@/lib/foods'
 import type { FoodFormData } from '@/lib/validations/food.schemas'
 
 const FoodForm = lazy(() => import('./FoodForm').then(m => ({ default: m.FoodForm })))
@@ -38,7 +39,7 @@ interface FoodModalsProps {
   isUpdating: boolean
   deletingFood: Food | null
   onDeleteDialogChange: (open: boolean) => void
-  onDeleteFood: () => void
+  onDeleteFood: (outcome?: FoodOutcome) => void
   isDeleting: boolean
 }
 
@@ -95,24 +96,50 @@ export function FoodModals({
         </DialogContent>
       </Dialog>
 
-      {/* Delete Confirmation Dialog */}
+      {/* Conferma eliminazione: chiede com'è finita, non «sei sicuro?» */}
       <AlertDialog open={!!deletingFood} onOpenChange={(open) => !open && onDeleteDialogChange(false)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Conferma Eliminazione</AlertDialogTitle>
+            <AlertDialogTitle>Com'è finita?</AlertDialogTitle>
             <AlertDialogDescription>
-              Sei sicuro di voler eliminare "{deletingFood?.name}"? Questa azione non può essere annullata.
+              «{deletingFood?.name}» esce dalla lista. Dirci come aiuta a capire quanto cibo
+              finisce nella spazzatura — se è stato un errore, puoi togliere e basta.
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Annulla</AlertDialogCancel>
+
+          {/* In colonna: sono tre scelte fra pari, non un'azione con due varianti.
+              Su telefono resta anche l'unica disposizione che tiene i bersagli larghi. */}
+          <div className="flex flex-col gap-2 py-2">
             <AlertDialogAction
-              onClick={onDeleteFood}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => onDeleteFood('consumed')}
               disabled={isDeleting}
+              className="h-11 w-full justify-start"
             >
-              {isDeleting ? 'Eliminazione...' : 'Elimina'}
+              <Check className="h-4 w-4 mr-2" aria-hidden="true" />
+              L'ho consumato
             </AlertDialogAction>
+            <AlertDialogAction
+              onClick={() => onDeleteFood('wasted')}
+              disabled={isDeleting}
+              className="h-11 w-full justify-start bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" />
+              L'ho buttato
+            </AlertDialogAction>
+            {/* Nessun esito: è l'errore di inserimento. Sporcare la metrica
+                anti-spreco con gli errori la rende inutile quanto lasciarla vuota. */}
+            <AlertDialogAction
+              onClick={() => onDeleteFood()}
+              disabled={isDeleting}
+              className="h-11 w-full justify-start bg-secondary text-secondary-foreground hover:bg-secondary/80"
+            >
+              <X className="h-4 w-4 mr-2" aria-hidden="true" />
+              Toglilo e basta
+            </AlertDialogAction>
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel className="h-11">Annulla</AlertDialogCancel>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/foods/__tests__/FoodCard.test.tsx
+++ b/src/components/foods/__tests__/FoodCard.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { FoodCard } from '../FoodCard'
 import type { Food } from '@/lib/foods'
 
@@ -103,5 +103,78 @@ describe('FoodCard — accessibilità & identità', () => {
     const note = screen.getByText('Aprire entro 2 giorni')
     expect(note.className).toContain('bg-muted')
     expect(note.className).not.toMatch(/bg-amber/)
+  })
+})
+
+describe('FoodCard — alternativa allo swipe (WCAG 2.5.1, livello A)', () => {
+  it('espone un menu azioni raggiungibile, non nascosto dietro il breakpoint', () => {
+    // I pulsanti del footer sono `hidden sm:flex`, e `display: none` non è
+    // «nascosto visivamente»: toglie dall'albero di accessibilità. Sotto i
+    // 640px lo swipe era l'unica strada, ed è `aria-hidden`.
+    render(<FoodCard food={makeFood()} onEdit={vi.fn()} onDelete={vi.fn()} />)
+
+    const trigger = screen.getByRole('button', { name: 'Azioni per Latte' })
+
+    // Nessun antenato lo toglie dal rendering a larghezza da telefono.
+    for (let node = trigger.parentElement; node; node = node.parentElement) {
+      expect(node.className).not.toMatch(/(^|\s)hidden(\s|$)/)
+      expect(node.getAttribute('aria-hidden')).not.toBe('true')
+    }
+  })
+
+  it('il menu si apre da tastiera e collega le stesse azioni', async () => {
+    // Aperto con Enter, non col mouse: è la strada di chi non può fare lo
+    // swipe, ed è il motivo per cui questo menu esiste.
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+    const food = makeFood()
+    render(<FoodCard food={food} onEdit={onEdit} onDelete={onDelete} />)
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Azioni per Latte' }), { key: 'Enter' })
+
+    const elimina = await screen.findByRole('menuitem', { name: /Elimina/ })
+    expect(screen.getByRole('menuitem', { name: /Modifica/ })).toBeTruthy()
+
+    fireEvent.click(elimina)
+    expect(onDelete).toHaveBeenCalledWith(food)
+  })
+
+  it('senza azioni disponibili non mostra un menu vuoto', () => {
+    render(<FoodCard food={makeFood()} />)
+    expect(screen.queryByRole('button', { name: /Azioni per/ })).toBeNull()
+  })
+
+  it('il bersaglio del menu resta ≥44px, come il resto dell\'app', () => {
+    render(<FoodCard food={makeFood()} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    const trigger = screen.getByRole('button', { name: 'Azioni per Latte' })
+    expect(trigger.className).toContain('h-11')
+    expect(trigger.className).toContain('w-11')
+  })
+})
+
+describe('FoodCard — a ogni larghezza esiste esattamente una strada', () => {
+  it('il menu ⋮ e i pulsanti del footer si escludono a vicenda', () => {
+    // Se qualcuno cambia uno dei due breakpoint senza toccare l'altro, si
+    // ricade nel difetto originale (nessuna strada sotto i 640px) o nella
+    // duplicazione (due strade sopra). L'invariante vive in due classi
+    // Tailwind in due punti del file: qui lo teniamo fermo.
+    const { container } = render(
+      <FoodCard food={makeFood()} onEdit={vi.fn()} onDelete={vi.fn()} />
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Azioni per Latte' })
+    const footer = container.querySelector('[class*="hidden"][class*="sm:flex"]')
+
+    expect(footer).not.toBeNull()
+    expect(trigger.className).toContain('sm:hidden')
+    // Il trigger non è nascosto di base: sotto i 640px c'è.
+    expect(trigger.className).not.toMatch(/(^|\s)hidden(\s|$)/)
+  })
+
+  it('i pulsanti del footer restano quelli di prima', () => {
+    render(<FoodCard food={makeFood()} onEdit={vi.fn()} onDelete={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Modifica Latte' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Elimina Latte' })).toBeTruthy()
   })
 })

--- a/src/components/foods/__tests__/FoodModals.test.tsx
+++ b/src/components/foods/__tests__/FoodModals.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+/**
+ * La conferma di eliminazione non chiede «sei sicuro?», chiede **com'è finita**.
+ *
+ * La domanda «sei sicuro?» non produce nessun dato: l'utente ha già deciso
+ * premendo Elimina. La stessa interazione, chiesta diversamente, dice se quel
+ * cibo è stato mangiato o buttato — che è l'unico modo per sapere quanto se ne
+ * spreca.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { FoodModals } from '../FoodModals'
+import type { Food } from '@/lib/foods'
+
+afterEach(cleanup)
+
+const FOOD = { id: 'food-1', name: 'Yogurt greco' } as Food
+
+function renderDialog(onDeleteFood = vi.fn(), isDeleting = false) {
+  render(
+    <FoodModals
+      isAddDialogOpen={false}
+      onAddDialogChange={vi.fn()}
+      onCreateFood={vi.fn()}
+      isCreating={false}
+      editingFood={null}
+      onEditDialogChange={vi.fn()}
+      onUpdateFood={vi.fn()}
+      isUpdating={false}
+      deletingFood={FOOD}
+      onDeleteDialogChange={vi.fn()}
+      onDeleteFood={onDeleteFood}
+      isDeleting={isDeleting}
+    />
+  )
+  return onDeleteFood
+}
+
+describe('conferma eliminazione — chiede l\'esito', () => {
+  it('offre le tre uscite, non un sì/no', () => {
+    renderDialog()
+
+    expect(screen.getByRole('button', { name: /L'ho consumato/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /L'ho buttato/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Toglilo e basta/ })).toBeTruthy()
+  })
+
+  it('nomina l\'alimento, così non si elimina quello sbagliato', () => {
+    renderDialog()
+    expect(screen.getByText(/Yogurt greco/)).toBeTruthy()
+  })
+
+  it('«consumato» registra l\'esito', () => {
+    const onDeleteFood = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: /L'ho consumato/ }))
+
+    expect(onDeleteFood).toHaveBeenCalledWith('consumed')
+  })
+
+  it('«buttato» registra l\'esito', () => {
+    const onDeleteFood = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: /L'ho buttato/ }))
+
+    expect(onDeleteFood).toHaveBeenCalledWith('wasted')
+  })
+
+  it('«toglilo e basta» non registra nessun esito', () => {
+    // È l'errore di inserimento: sporcare la metrica anti-spreco con gli
+    // errori la rende inutile quanto lasciarla vuota.
+    const onDeleteFood = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: /Toglilo e basta/ }))
+
+    expect(onDeleteFood).toHaveBeenCalledWith()
+    expect(onDeleteFood.mock.calls[0]).toHaveLength(0)
+  })
+
+  it('si può ancora annullare senza togliere niente', () => {
+    const onDeleteFood = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Annulla' }))
+
+    expect(onDeleteFood).not.toHaveBeenCalled()
+  })
+
+  it('tutte le scelte hanno un bersaglio ≥44px', () => {
+    renderDialog()
+
+    for (const nome of [/L'ho consumato/, /L'ho buttato/, /Toglilo e basta/, /^Annulla$/]) {
+      expect(screen.getByRole('button', { name: nome }).className).toContain('h-11')
+    }
+  })
+
+  it('durante l\'eliminazione non si può premere due volte', () => {
+    renderDialog(vi.fn(), true)
+
+    for (const nome of [/L'ho consumato/, /L'ho buttato/, /Toglilo e basta/]) {
+      expect(screen.getByRole('button', { name: nome }).hasAttribute('disabled')).toBe(true)
+    }
+  })
+})

--- a/src/hooks/useFoodFormDialog.ts
+++ b/src/hooks/useFoodFormDialog.ts
@@ -3,7 +3,7 @@ import { toast } from 'sonner'
 import { onlineManager } from '@tanstack/react-query'
 import { useAuth } from './useAuth'
 import { useCreateFood, useUpdateFood, useDeleteFood } from './useFoods'
-import type { Food, FoodInsert, FoodUpdate } from '@/lib/foods'
+import type { Food, FoodInsert, FoodUpdate, FoodOutcome } from '@/lib/foods'
 import type { FoodFormData } from '@/lib/validations/food.schemas'
 import { triggerHaptic } from '@/lib/haptics'
 
@@ -115,10 +115,10 @@ export function useFoodFormDialog() {
     }
   }
 
-  const handleDeleteFood = () => {
+  const handleDeleteFood = (outcome?: FoodOutcome) => {
     if (!deletingFood) return
 
-    deleteMutation.mutate(deletingFood.id)
+    deleteMutation.mutate({ id: deletingFood.id, outcome })
     triggerHaptic('error')
     setDeletingFood(null)
 

--- a/src/hooks/useFoods.ts
+++ b/src/hooks/useFoods.ts
@@ -9,7 +9,7 @@ import {
   type FoodUpdate,
   type FilterParams,
 } from '@/lib/foods'
-import { mutationKeys } from '@/lib/mutationDefaults'
+import { mutationKeys, type DeleteFoodVariables } from '@/lib/mutationDefaults'
 
 type PreviousListsContext = { previousLists: [unknown, Food[] | undefined][] }
 
@@ -180,7 +180,7 @@ export function useUpdateFood() {
 }
 
 /**
- * Delete a food item.
+ * Toglie un alimento dalla lista, registrandone l'esito quando c'è.
  *
  * Note: mutationFn is provided by registerMutationDefaults().
  */
@@ -189,19 +189,19 @@ export function useDeleteFood() {
 
   return useMutation({
     mutationKey: mutationKeys.deleteFood,
-    onMutate: async (deletedId: string) => {
+    onMutate: async ({ id }: DeleteFoodVariables) => {
       await queryClient.cancelQueries({ queryKey: foodsKeys.lists() })
 
       const previousLists = queryClient.getQueriesData<Food[]>({ queryKey: foodsKeys.lists() })
 
       queryClient.setQueriesData<Food[]>(
         { queryKey: foodsKeys.lists() },
-        (old) => old?.filter((food) => food.id !== deletedId),
+        (old) => old?.filter((food) => food.id !== id),
       )
 
       return { previousLists }
     },
-    onError: (error: Error, _deletedId: string, context) => {
+    onError: (error: Error, _variables: DeleteFoodVariables, context) => {
       restorePreviousLists(queryClient, context)
       toast.error(error.message || 'Errore nell\'eliminazione dell\'alimento')
     },

--- a/src/lib/__tests__/foodsSoftDelete.test.ts
+++ b/src/lib/__tests__/foodsSoftDelete.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Togliere un alimento dalla lista senza distruggere il dato che serve a
+ * capire com'è finito.
+ *
+ * Prima l'eliminazione era una DELETE vera: la riga spariva insieme all'esito,
+ * quindi registrare «l'ho consumato» e poi eliminare avrebbe scritto un dato e
+ * subito dopo l'avrebbe buttato. Ora è una sola UPDATE che imposta
+ * `deleted_at`, azzera `image_url` e registra l'esito — atomica, e offline una
+ * sola voce in coda invece di due che si possono separare.
+ *
+ * L'immagine invece viene cancellata davvero: è un blob pesante e non serve a
+ * nessuna metrica.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockAuth, mockFrom, mockBuilder, mockDeleteFoodImage, mockDeletePendingImage } =
+  vi.hoisted(() => {
+    const mockBuilder = {
+      select: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn(),
+    }
+    return {
+      mockAuth: { getSession: vi.fn() },
+      mockFrom: vi.fn(() => mockBuilder),
+      mockBuilder,
+      mockDeleteFoodImage: vi.fn(),
+      mockDeletePendingImage: vi.fn(),
+    }
+  })
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { auth: mockAuth, from: mockFrom },
+}))
+
+vi.mock('@/lib/storage', () => ({
+  deleteFoodImage: mockDeleteFoodImage,
+}))
+
+vi.mock('@/lib/pendingImages', () => ({
+  isPendingUrl: (url: unknown) => typeof url === 'string' && url.startsWith('pending://'),
+  deletePendingImage: mockDeletePendingImage,
+}))
+
+import { softDeleteFood } from '@/lib/foods'
+
+const USER_ID = 'user-1'
+const FOOD_ID = 'food-1'
+
+/** L'UPDATE finale, cioè l'unica scrittura che questa funzione fa. */
+function updatePayload(): Record<string, unknown> {
+  return mockBuilder.update.mock.calls[0][0]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockAuth.getSession.mockResolvedValue({
+    data: { session: { user: { id: USER_ID } } },
+    error: null,
+  })
+  // Prima chiamata: la lettura di image_url. Seconda: l'UPDATE.
+  mockBuilder.single
+    .mockResolvedValueOnce({ data: { image_url: null }, error: null })
+    .mockResolvedValue({ data: { id: FOOD_ID }, error: null })
+  mockDeleteFoodImage.mockResolvedValue(undefined)
+  mockDeletePendingImage.mockResolvedValue(undefined)
+})
+
+describe('softDeleteFood — la riga sopravvive', () => {
+  it('imposta deleted_at invece di distruggere la riga', async () => {
+    const { error } = await softDeleteFood(FOOD_ID)
+
+    expect(error).toBeNull()
+    expect(updatePayload().deleted_at).toEqual(expect.any(String))
+    // Nessuna DELETE: è il punto di tutta la modifica.
+    expect(mockBuilder).not.toHaveProperty('delete')
+  })
+
+  it('senza esito non scrive nessuno status', async () => {
+    // «Toglilo e basta» è l'errore di inserimento: sporcare la metrica
+    // anti-spreco con gli errori la rende inutile quanto lasciarla vuota.
+    await softDeleteFood(FOOD_ID)
+
+    expect(updatePayload()).not.toHaveProperty('status')
+    expect(updatePayload()).not.toHaveProperty('consumed_at')
+  })
+
+  it('registra «consumato» con il momento in cui è successo', async () => {
+    await softDeleteFood(FOOD_ID, 'consumed')
+
+    expect(updatePayload().status).toBe('consumed')
+    expect(updatePayload().consumed_at).toEqual(expect.any(String))
+  })
+
+  it('registra «buttato» senza consumed_at, che non avrebbe senso', async () => {
+    await softDeleteFood(FOOD_ID, 'wasted')
+
+    expect(updatePayload().status).toBe('wasted')
+    expect(updatePayload()).not.toHaveProperty('consumed_at')
+  })
+
+  it('esito e rimozione stanno nella stessa UPDATE', async () => {
+    // Una scrittura sola: non c'è un ordine da scegliere, né uno stato
+    // intermedio in cui l'esito è registrato ma l'alimento è ancora in lista.
+    await softDeleteFood(FOOD_ID, 'consumed')
+
+    expect(mockBuilder.update).toHaveBeenCalledTimes(1)
+    expect(updatePayload()).toMatchObject({
+      status: 'consumed',
+      deleted_at: expect.any(String),
+    })
+  })
+})
+
+describe('softDeleteFood — l\'immagine invece sparisce davvero', () => {
+  it('cancella il blob su Storage e azzera image_url', async () => {
+    mockBuilder.single
+      .mockReset()
+      .mockResolvedValueOnce({ data: { image_url: `${USER_ID}/foto.jpg` }, error: null })
+      .mockResolvedValue({ data: { id: FOOD_ID }, error: null })
+
+    await softDeleteFood(FOOD_ID)
+
+    expect(mockDeleteFoodImage).toHaveBeenCalledWith(`${USER_ID}/foto.jpg`, USER_ID)
+    // Azzerare il riferimento è parte del contratto: un puntatore a un blob
+    // che non c'è più è peggio di nessun puntatore.
+    expect(updatePayload().image_url).toBeNull()
+  })
+
+  it('per un\'immagine ancora in coda la toglie da IndexedDB, non da Storage', async () => {
+    mockBuilder.single
+      .mockReset()
+      .mockResolvedValueOnce({ data: { image_url: 'pending://abc-123' }, error: null })
+      .mockResolvedValue({ data: { id: FOOD_ID }, error: null })
+
+    await softDeleteFood(FOOD_ID)
+
+    expect(mockDeletePendingImage).toHaveBeenCalledWith('pending://abc-123')
+    expect(mockDeleteFoodImage).not.toHaveBeenCalled()
+    expect(updatePayload().image_url).toBeNull()
+  })
+
+  it('se la cancellazione dell\'immagine fallisce, l\'alimento esce comunque dalla lista', async () => {
+    // L'utente ha chiesto di togliere l'alimento: un blob rimasto indietro è
+    // un problema di spazio, non un motivo per disobbedire.
+    mockBuilder.single
+      .mockReset()
+      .mockResolvedValueOnce({ data: { image_url: `${USER_ID}/foto.jpg` }, error: null })
+      .mockResolvedValue({ data: { id: FOOD_ID }, error: null })
+    mockDeleteFoodImage.mockRejectedValue(new Error('Storage irraggiungibile'))
+
+    const { error } = await softDeleteFood(FOOD_ID)
+
+    expect(error).toBeNull()
+    expect(updatePayload().deleted_at).toEqual(expect.any(String))
+  })
+
+  it('senza immagine non tocca lo Storage', async () => {
+    await softDeleteFood(FOOD_ID)
+
+    expect(mockDeleteFoodImage).not.toHaveBeenCalled()
+    expect(mockDeletePendingImage).not.toHaveBeenCalled()
+  })
+})
+
+describe('softDeleteFood — errori', () => {
+  it('senza sessione non scrive niente', async () => {
+    mockAuth.getSession.mockResolvedValue({ data: { session: null }, error: null })
+
+    const { error } = await softDeleteFood(FOOD_ID)
+
+    expect(error?.message).toBe('Utente non autenticato')
+    expect(mockBuilder.update).not.toHaveBeenCalled()
+  })
+
+  it('riporta l\'errore dell\'UPDATE invece di sollevare', async () => {
+    mockBuilder.single
+      .mockReset()
+      .mockResolvedValueOnce({ data: { image_url: null }, error: null })
+      .mockResolvedValue({ data: null, error: { message: 'permission denied for table foods' } })
+
+    const { error } = await softDeleteFood(FOOD_ID)
+
+    expect(error?.message).toBe('permission denied for table foods')
+  })
+})

--- a/src/lib/foods.ts
+++ b/src/lib/foods.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase'
 import type { Database } from './supabase'
 import { deleteFoodImage } from './storage'
+import { isPendingUrl, deletePendingImage } from './pendingImages'
 import { EXPIRY_SOON_DAYS } from './expiry'
 
 /**
@@ -284,11 +285,59 @@ export async function updateFood(id: string, foodData: FoodUpdate): Promise<Food
 }
 
 /**
- * Delete a food item (hard delete)
- * For soft delete, use updateFood with deleted_at timestamp
- * Also deletes associated image from storage if exists
+ * Butta via l'immagine di un alimento, ovunque si trovi.
+ *
+ * Un'immagine ancora in coda (`pending://`) non è mai arrivata su Storage: sta
+ * in IndexedDB e va tolta da lì. Il fallimento non è un motivo per fermarsi —
+ * l'utente ha chiesto di togliere l'alimento, e un blob rimasto indietro è un
+ * problema di spazio, non una ragione per disobbedire.
  */
-export async function deleteFood(id: string): Promise<{ error: Error | null }> {
+async function discardFoodImage(imageUrl: string | null | undefined, userId: string): Promise<void> {
+  if (!imageUrl) return
+
+  try {
+    if (isPendingUrl(imageUrl)) {
+      await deletePendingImage(imageUrl)
+    } else {
+      await deleteFoodImage(imageUrl, userId)
+    }
+  } catch {
+    // Solo il contesto, senza l'oggetto errore: passarlo alla console ne
+    // stamperebbe le proprietà (vedi #79). Diventerà `logError` da @/lib/safeLog
+    // quando la #83 sarà mergiata, e allora il messaggio tornerà utile.
+    console.warn('Immagine non cancellata, l\'alimento viene tolto comunque')
+  }
+}
+
+/**
+ * L'esito di un alimento tolto dalla lista, quando l'utente lo dichiara.
+ *
+ * Scritto a mano e non derivato da `Food['status']`, che nei tipi generati è
+ * `string | null` e quindi non vincola niente: il vocabolario vero sta nel
+ * check constraint della tabella `foods` (`active`/`consumed`/`expired`/
+ * `wasted`). Qui restano solo i due valori che una persona può *scegliere* —
+ * `expired` si ricava dalla data e non è un esito che qualcuno dichiara.
+ */
+export type FoodOutcome = 'consumed' | 'wasted'
+
+/**
+ * Toglie un alimento dalla lista registrandone l'esito, in una sola scrittura.
+ *
+ * `deleted_at` risponde a «lo traccio ancora?», `status` a «com'è finita?»:
+ * sono due assi indipendenti, e `getFoods` filtra solo sul primo. Stanno nella
+ * stessa UPDATE perché separarli lascerebbe uno stato intermedio in cui
+ * l'esito è registrato ma l'alimento è ancora in lista — e offline due voci in
+ * coda che si possono separare per davvero.
+ *
+ * `outcome` omesso significa «toglilo e basta»: è l'errore di inserimento, e
+ * deve restare senza esito. Sporcare la metrica anti-spreco con gli errori la
+ * rende inutile quanto lasciarla vuota.
+ *
+ * L'immagine invece viene cancellata davvero: è un blob pesante, non serve a
+ * nessuna metrica, e tenerlo farebbe crescere lo Storage a ogni eliminazione.
+ * È l'unica parte irreversibile — la riga si può ripristinare, la foto no.
+ */
+export async function softDeleteFood(id: string, outcome?: FoodOutcome): Promise<FoodResponse> {
   try {
     const { data: { session }, error: authError } = await supabase.auth.getSession()
 
@@ -296,55 +345,33 @@ export async function deleteFood(id: string): Promise<{ error: Error | null }> {
       throw new Error('Utente non autenticato')
     }
 
-    const user = session.user
-
-    // First, get the food to check if it has an image
-    const { data: food, error: fetchError } = await supabase
+    const { data: existing } = await supabase
       .from('foods')
       .select('image_url')
       .eq('id', id)
       .single()
 
-    if (fetchError) {
-      throw new Error(fetchError.message)
+    await discardFoodImage(existing?.image_url, session.user.id)
+
+    // Un solo istante per tutta la scrittura: è un evento unico, e `consumed_at`
+    // non deve risultare successivo al `deleted_at` della stessa UPDATE.
+    const now = new Date().toISOString()
+
+    const updateData: FoodUpdate = {
+      deleted_at: now,
+      image_url: null,
     }
 
-    // Delete image from storage if exists
-    if (food?.image_url) {
-      try {
-        await deleteFoodImage(food.image_url, user.id)
-      } catch (imageError) {
-        console.warn('Failed to delete image, continuing with food deletion:', imageError)
-        // Continue with food deletion even if image deletion fails
+    if (outcome) {
+      updateData.status = outcome
+      if (outcome === 'consumed') {
+        updateData.consumed_at = now
       }
     }
 
-    // Delete food from database
-    const { error } = await supabase
-      .from('foods')
-      .delete()
-      .eq('id', id)
-
-    if (error) {
-      throw new Error(error.message)
-    }
-
-    return { error: null }
-  } catch (error) {
-    return {
-      error: error instanceof Error ? error : new Error('Errore nell\'eliminazione dell\'alimento'),
-    }
-  }
-}
-
-/**
- * Soft delete a food item by setting deleted_at timestamp
- */
-export async function softDeleteFood(id: string): Promise<FoodResponse> {
-  try {
     const { data, error } = await supabase
       .from('foods')
-      .update({ deleted_at: new Date().toISOString() })
+      .update(updateData)
       .eq('id', id)
       .select()
       .single()

--- a/src/lib/foods.ts
+++ b/src/lib/foods.ts
@@ -2,6 +2,7 @@ import { supabase } from './supabase'
 import type { Database } from './supabase'
 import { deleteFoodImage } from './storage'
 import { isPendingUrl, deletePendingImage } from './pendingImages'
+import { logError } from './safeLog'
 import { EXPIRY_SOON_DAYS } from './expiry'
 
 /**
@@ -301,11 +302,11 @@ async function discardFoodImage(imageUrl: string | null | undefined, userId: str
     } else {
       await deleteFoodImage(imageUrl, userId)
     }
-  } catch {
-    // Solo il contesto, senza l'oggetto errore: passarlo alla console ne
-    // stamperebbe le proprietà (vedi #79). Diventerà `logError` da @/lib/safeLog
-    // quando la #83 sarà mergiata, e allora il messaggio tornerà utile.
-    console.warn('Immagine non cancellata, l\'alimento viene tolto comunque')
+  } catch (error) {
+    // `logError` stampa il solo messaggio, ripulito: passare l'oggetto alla
+    // console ne stamperebbe le proprietà, dove i client Supabase mettono i
+    // dati della risposta (#79).
+    logError('Immagine non cancellata, l\'alimento viene tolto comunque:', error)
   }
 }
 

--- a/src/lib/mutationDefaults.ts
+++ b/src/lib/mutationDefaults.ts
@@ -2,11 +2,12 @@ import type { QueryClient } from '@tanstack/react-query'
 import {
   createFood,
   updateFood,
-  deleteFood,
+  softDeleteFood,
   updateFoodStatus,
   type Food,
   type FoodInsert,
   type FoodUpdate,
+  type FoodOutcome,
 } from './foods'
 import { mutationTracker } from './realtime'
 import { uploadFoodImage } from './storage'
@@ -20,6 +21,12 @@ export const mutationKeys = {
   updateFood: ['updateFood'] as const,
   deleteFood: ['deleteFood'] as const,
   updateFoodStatus: ['updateFoodStatus'] as const,
+}
+
+/** Cosa serve per togliere un alimento: quale, e com'è finita se l'utente lo dice. */
+export interface DeleteFoodVariables {
+  id: string
+  outcome?: FoodOutcome
 }
 
 /**
@@ -87,10 +94,11 @@ export function registerMutationDefaults(queryClient: QueryClient): void {
   })
 
   queryClient.setMutationDefaults(mutationKeys.deleteFood, {
-    mutationFn: async (id: string) => {
-      mutationTracker.track(id, 'DELETE')
-      const { error } = await deleteFood(id)
-      if (error) throw error
+    mutationFn: async (variables: DeleteFoodVariables) => {
+      // Una sola scrittura: `deleted_at` e l'esito insieme. La riga resta
+      // (serve alla metrica anti-spreco), l'immagine no.
+      mutationTracker.track(variables.id, 'UPDATE')
+      return unwrapFood(await softDeleteFood(variables.id, variables.outcome))
     },
   })
 


### PR DESCRIPTION
## Prima di tutto: la premessa di questa PR era sbagliata

Era descritta come «collegare `useUpdateFoodStatus`, che esiste ma non ha chiamanti» — due scritture, l'esito e il soft delete, da ordinare con cura. Verificando prima di scrivere:

**`deleteFood` non era un soft delete.** Faceva `.delete().eq('id', id)`, una DELETE vera, e prima cancellava anche l'immagine. Il modello a due assi (`deleted_at` = «lo traccio ancora», `status` = «com'è finita») era vero nello **schema** ma non esisteva nel **codice**: `getFoods` filtrava su `deleted_at IS NULL`, ma nessuno scriveva mai quella colonna, perché la riga veniva distrutta.

Quindi la PR come specificata avrebbe scritto `status = 'consumed'` e subito dopo distrutto la riga che lo conteneva. La feature sarebbe *sembrata* funzionare e la metrica anti-spreco sarebbe rimasta vuota per sempre, senza che nessuno capisse perché.

`softDeleteFood` esisteva già, impostava `deleted_at`, e non aveva chiamanti — esattamente come `useUpdateFoodStatus`. Due funzioni scritte e mai collegate, con in mezzo una hard delete che faceva il lavoro.

**La domanda sull'ordine delle due scritture è svanita di conseguenza.** Non servono due scritture: `deleted_at`, l'esito e l'azzeramento di `image_url` stanno in **una sola UPDATE**. Niente ordine da scegliere, niente stato intermedio in cui l'esito è registrato ma l'alimento è ancora in lista, e offline **una sola voce in coda** invece di due — che conta, perché `resumePausedMutations` le fa ripartire in parallelo, non in sequenza.

## Cosa cambia

### La conferma chiede l'esito

«Sei sicuro?» non produce nessun dato: l'utente ha già deciso premendo Elimina. La stessa interazione, chiesta diversamente, dice se quel cibo è stato mangiato o buttato.

- **L'ho consumato** → `status = 'consumed'` + `consumed_at`
- **L'ho buttato** → `status = 'wasted'`
- **Toglilo e basta** → nessun esito

La terza resta deliberatamente senza esito: è l'errore di inserimento, e sporcare la metrica anti-spreco con gli errori la rende inutile quanto lasciarla vuota. A livello di codice è la differenza fra `onDeleteFood()` e `onDeleteFood(undefined)` — c'è un test che asserisce che la chiamata abbia **zero** argomenti, ed è il motivo per cui i tre pulsanti non sono un `.map()` su un array di scelte.

### L'eliminazione non distrugge più la riga, ma l'immagine sì

La riga sopravvive con `deleted_at`: serve alla metrica. L'immagine viene cancellata davvero — da Storage, o da IndexedDB se era ancora un caricamento `pending://` mai arrivato al server. È un blob pesante che non serve a nessuna metrica, e tenerlo farebbe crescere lo spazio occupato a ogni eliminazione.

**È l'unica parte irreversibile**: la riga si può ripristinare, la foto no. `image_url` viene azzerato nella stessa UPDATE, perché un puntatore a un blob che non c'è più è peggio di nessun puntatore.

Se la cancellazione dell'immagine fallisce, l'alimento esce comunque dalla lista. L'utente ha chiesto quello; un blob rimasto indietro è un problema di spazio, non un motivo per disobbedire.

**Per chi usa l'app la lista si comporta esattamente come prima**, perché `getFoods` filtrava già su `deleted_at IS NULL`.

### Il difetto di accessibilità

Verificato riga per riga, non sospettato. `FoodCard.tsx` metteva Modifica ed Elimina in un `CardFooter` con `hidden sm:flex`, quindi sotto i 640px sparivano. `SwipeableCard` non offriva alternative: i livelli d'azione sono `aria-hidden="true"` e il contenitore ha `tabIndex={-1}`. Su telefono con uno screen reader **non esisteva alcun modo di modificare o eliminare un alimento**. `display: none` non è «nascosto visivamente»: è fuori dall'albero di accessibilità. WCAG 2.5.1 *Pointer Gestures*, livello A.

Nuovo menu ⋮ nell'header della card, 44×44, che apre le stesse voci. Lo swipe resta invariato per chi lo usa.

Il menu è `sm:hidden`, **complemento esatto** di `hidden sm:flex` sul footer: sotto i 640px c'è il menu, sopra ci sono i pulsanti, mai entrambi e mai nessuno dei due. È un invariante fragile — due classi Tailwind in due punti del file — quindi c'è un test che lo tiene fermo. Senza, la prima versione mostrava Modifica ed Elimina **due volte** sul desktop.

## Copertura

**28 test nuovi.** Quelli sul layer dati sono partiti rossi su 7 casi.

- `softDeleteFood` (11): imposta `deleted_at` invece di distruggere; senza esito non scrive nessuno `status`; `consumed_at` solo per `consumed` e mai per `wasted`; esito e rimozione nella stessa UPDATE; cancella il blob da Storage e azzera `image_url`; per un'immagine ancora in coda passa da IndexedDB e non da Storage; se la cancellazione fallisce l'alimento esce comunque; senza sessione non scrive niente; riporta l'errore invece di sollevare.
- Il dialogo (8): le tre uscite, l'alimento nominato, ogni esito collegato al valore giusto, «toglilo e basta» con zero argomenti, Annulla che non toglie niente, bersagli ≥44px, e i pulsanti disabilitati durante l'operazione.
- `FoodCard` (6): il menu esiste e nessun antenato lo toglie dall'albero di accessibilità; **si apre da tastiera** — non col mouse, perché è la strada di chi non può fare lo swipe; collega le stesse azioni; non compare se non ci sono azioni; bersaglio ≥44px; e l'invariante di complementarità col footer.

## Verifiche

- [x] `npm run lint` — 0 errori, 5 warning `react-refresh/only-export-components` preesistenti e invariati
- [x] `npm run typecheck` — pulito
- [x] `npm test` — 280 test su 47 file, tutti verdi (255/45 su `main`)
- [x] `npm run build` — ok

## Database e sicurezza

- [x] Nessuna modifica database
- [ ] Migration additive con RLS e GRANT espliciti
- [x] Autorizzazione e azioni distruttive coperte da test o smoke test

Nessuna migrazione: `deleted_at`, `status` e i valori dell'enum sono nella baseline dal 9 gennaio. Cambia solo quali colonne il client scrive.

## UI/mobile

- [x] Nessuna modifica UI
- [ ] Verificata in viewport mobile
- [x] Testi e documentazione aggiornati se cambia il comportamento utente

> **Verifica mobile non eseguita, e qui pesa più che nelle PR precedenti**: il difetto che questa PR chiude è di accessibilità su telefono, e i test di componente provano che il menu è nell'albero e si apre da tastiera, non che uno screen reader reale lo annunci in modo sensato. Se vuoi la conferma con VoiceOver su iPhone, va fatta prima del merge — è l'unico modo di sapere se il rimedio funziona davvero.

## Effetti da conoscere

- **Le righe eliminate ora si accumulano.** Nessuna pulizia programmata: va deciso a parte se e quando rimuoverle davvero (c'è un aspetto di minimizzazione dei dati). Le immagini invece no, quelle spariscono subito.
- **Gli alimenti tolti prima di questa PR non esistono più**, quindi non hanno esito né potranno averlo. Quelli che verranno tolti con «Toglilo e basta» vanno letti come **«esito non registrato», non «nessuno spreco»**.

## Correlate

- Aperta **#85** durante l'implementazione: `Food['status']` è `string | null` nei tipi generati, perché i check constraint non arrivano al generatore. `useUpdateFoodStatus` accetta a tipo qualsiasi stringa, e il vocabolario è ridichiarato a mano in tre punti TypeScript. Nessuna divergenza in corso — le copie combaciano — ma il meccanismo era già noto dal 6 luglio (`FoodForm.tsx:136-141`, PR #68) e la duplicazione era stata segnalata e rimandata il 10 giugno. `FoodOutcome` qui è scritto a mano apposta, con il perché nel commento.
