### PR TITLE
fix(alimenti): la validazione della quantità rifiuta ciò che il DB rifiuta (v1.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,7 +524,8 @@ Lancio pubblico di Entro su LinkedIn.
 - Sistema di autenticazione Supabase completo
 - CRUD completo gestione alimenti con React Query
 
-[Unreleased]: https://github.com/E-Lop/entro/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/E-Lop/entro/compare/v1.11.1...HEAD
+[1.11.1]: https://github.com/E-Lop/entro/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/E-Lop/entro/compare/v1.10.7...v1.11.0
 [1.10.7]: https://github.com/E-Lop/entro/compare/v1.10.6...v1.10.7
 [1.10.6]: https://github.com/E-Lop/entro/compare/v1.10.5...v1.10.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.11.1] - 2026-08-12
+
+### Fixed
+- **La validazione della quantità accettava valori che il database rifiuta.** Lo schema Zod usava `min(0)` — «La quantità non può essere negativa» — mentre la colonna è `numeric(10,2)` con `check (quantity > 0)`: lo zero superava la validazione del form e faceva fallire la scrittura. Il minimo non è nemmeno «maggiore di zero» sul valore digitato, ma **0.01**, il più piccolo positivo che la colonna sa memorizzare: un 0,004 passerebbe un controllo `> 0` e diventerebbe `0.00` alla scrittura, dove il CHECK scatta comunque. `null` resta valido e continua a significare «quantità non tracciata», che è cosa diversa da zero — se non ne hai più, l'alimento va toglierlo dalla lista. L'editor rapido non ci cadeva, perché `src/lib/quantity.ts` colmava già il divario lato stepper; ci cadeva il form.
+
 ## [1.11.0] - 2026-08-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/__tests__/foodSchemas.test.ts
+++ b/src/lib/__tests__/foodSchemas.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Vincoli di `foodFormSchema` sulla quantità.
+ *
+ * La colonna è `numeric(10,2)` con `check (quantity > 0)`: la validazione client
+ * deve rifiutare tutto ciò che il database rifiuterebbe, altrimenti il form
+ * passa e la scrittura fallisce. Regola nel bundle condiviso,
+ * `core/storage-and-units.md`.
+ */
+import { describe, it, expect } from 'vitest'
+import { foodFormSchema } from '@/lib/validations/food.schemas'
+
+/** Payload valido a cui sostituire il solo campo sotto esame. */
+function payload(over: Record<string, unknown> = {}) {
+  const domani = new Date()
+  domani.setDate(domani.getDate() + 1)
+  return {
+    name: 'Yogurt greco',
+    category_id: 'c1',
+    expiry_date: domani.toISOString().slice(0, 10),
+    storage_location: 'fridge' as const,
+    ...over,
+  }
+}
+
+function erroreQuantita(over: Record<string, unknown>): string | undefined {
+  const result = foodFormSchema.safeParse(payload(over))
+  if (result.success) return undefined
+  return result.error.issues.find((i) => i.path[0] === 'quantity')?.message
+}
+
+describe('foodFormSchema — quantità', () => {
+  it('accetta una quantità positiva', () => {
+    expect(foodFormSchema.safeParse(payload({ quantity: 2 })).success).toBe(true)
+  })
+
+  it('accetta l\'assenza di quantità: `null` significa "non tracciata"', () => {
+    expect(foodFormSchema.safeParse(payload({ quantity: null })).success).toBe(true)
+  })
+
+  it('accetta il campo omesso', () => {
+    expect(foodFormSchema.safeParse(payload()).success).toBe(true)
+  })
+
+  it('rifiuta una quantità negativa', () => {
+    expect(erroreQuantita({ quantity: -1 })).toBeTruthy()
+  })
+
+  it('rifiuta lo zero, che il database non accetta', () => {
+    // `check (quantity > 0)`: zero non è "nessuna quantità", è una contraddizione
+    // — se non ne hai più, l'alimento va togliersi dalla lista.
+    expect(erroreQuantita({ quantity: 0 })).toBeTruthy()
+  })
+
+  it('rifiuta un positivo che si arrotonda a zero alla precisione della colonna', () => {
+    // 0,004 supererebbe un controllo `> 0` fatto sul valore digitato, ma la
+    // colonna `numeric(10,2)` lo memorizza come 0.00 e il CHECK scatta lì.
+    expect(erroreQuantita({ quantity: 0.004 })).toBeTruthy()
+  })
+
+  it('accetta il più piccolo valore che la colonna può memorizzare', () => {
+    expect(foodFormSchema.safeParse(payload({ quantity: 0.01 })).success).toBe(true)
+  })
+})

--- a/src/lib/validations/food.schemas.ts
+++ b/src/lib/validations/food.schemas.ts
@@ -35,9 +35,14 @@ export const foodFormSchema = z.object({
       return selectedDate >= today
     }, 'La data di scadenza non può essere nel passato'),
   storage_location: storageLocationEnum,
+  // La colonna è `numeric(10,2)` con `check (quantity > 0)`. Il minimo non è
+  // quindi «maggiore di zero» sul valore digitato, ma 0.01: il più piccolo
+  // valore positivo che la colonna sa memorizzare. Un 0.004 passerebbe un
+  // controllo `> 0` e diventerebbe 0.00 alla scrittura, dove il CHECK scatta.
+  // `null` resta valido e significa «quantità non tracciata».
   quantity: z
     .number()
-    .min(0, 'La quantità non può essere negativa')
+    .min(0.01, 'La quantità deve essere maggiore di zero')
     .nullable()
     .optional(),
   quantity_unit: quantityUnitEnum.nullable().optional(),


### PR DESCRIPTION
Trovato leggendo `src/lib/quantity.ts`, che **dichiara** la divergenza in un commento e la colma solo per lo stepper.

## L'incongruenza

Lo schema Zod usava:

```ts
quantity: z.number().min(0, 'La quantità non può essere negativa')
```

mentre la colonna è `numeric(10,2)` con `constraint positive_quantity check (quantity > 0)`.

Lo zero superava la validazione del form e faceva fallire la scrittura. L'editor rapido non ci cadeva — `quantity.ts` colma il divario lato stepper con `minForUnit` — ma il form sì.

## Il minimo non è «maggiore di zero»: è 0.01

Il dettaglio che rende la correzione meno ovvia di quanto sembri. Un `0.004` supererebbe un controllo `> 0` fatto sul valore digitato, ma la colonna lo memorizza come `0.00` e il CHECK scatta lì. Il minimo corretto lato client è quindi il più piccolo positivo che la colonna sa rappresentare: **0.01**.

`null` resta valido e continua a significare «quantità non tracciata». Non è la stessa cosa dello zero: zero vorrebbe dire «ne ho zero e lo sto ancora tracciando», che è una contraddizione — se non ne hai più, l'alimento va toglierlo dalla lista, che è l'altro asse del ciclo di vita.

## Test

`food.schemas.ts` non aveva test. Aggiunti sette casi in `src/lib/__tests__/foodSchemas.test.ts`, scritti prima del fix: due erano rossi — lo zero e il valore che si arrotonda a zero — e sono esattamente i due che l'incongruenza produceva. Gli altri cinque tengono ferme le cose che devono continuare a passare: positivo, `null`, campo omesso, negativo rifiutato, e `0.01` accettato.

## Dominio, non solo codice

La regola è ora scritta nel bundle condiviso: [entro-family#7](https://github.com/E-Lop/entro-family/pull/7) aggiunge a `core/storage-and-units.md` il vincolo, i passi per unità, l'arrotondamento a due decimali e questa incongruenza.

Serviva perché la pagina elencava le unità e non diceva nulla sui limiti: progettando la dashboard di entro-mobile ho scritto «quantità a zero» come decisione da prendere, quando era uno stato non rappresentabile. Chi leggeva il bundle non trovava la risposta, e questo è ciò che il bundle esiste per evitare.

## Verifiche

`npx vitest run` **313 test su 50 file** · `npx tsc -b` pulito · `npx eslint .` 0 errori, 5 warning tutti preesistenti (`react-refresh/only-export-components`).

Versione a **1.11.1**, `package-lock.json` allineato, CHANGELOG in italiano sotto `Fixed`.

Una nota di trasparenza sulla convenzione del repo: non ho lanciato la skill `code-simplifier`, perché in questa sessione non posso avviare subagenti. Il diff è una riga di produzione più un commento e un file di test nuovo, e l'ho riletto io: se preferite passarlo comunque dal simplifier prima del merge, il posto dove guardare è solo `food.schemas.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)