### PR TITLE
refactor(tipi): il vocabolario delle colonne CHECK ha una fonte sola (v1.11.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Tutte le modifiche rilevanti al progetto Entro sono documentate in questo file.
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/)
 e il progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
 
+## [1.11.2] - 2026-08-14
+
+### Changed
+- **Il vocabolario delle colonne `text` + `CHECK` ha una sola fonte in TypeScript, e i tipi lo fanno rispettare.** `foods.status`, `foods.storage_location` e `foods.quantity_unit` non sono `enum` di Postgres: sono `text` con un `CHECK`, e il generatore di tipi Supabase non legge i check constraint. Da `supabase gen types` uscivano quindi come `string` e `string | null`, così `updateFoodStatus(id, 'banana')` compilava e lo sbaglio si manifestava come 400 a runtime invece che come errore del compilatore. Gli enum Zod di `validations/food.schemas.ts` diventano la fonte unica lato TypeScript — sono gli unici dei punti che ridichiaravano quelle liste a validare davvero qualcosa — e un nuovo `lib/supabase.overrides.ts` li usa per restringere le righe generate. Passando dal punto in cui il client viene costruito, il restringimento vale anche per le scritture. Sono sparite sei copie inline del vocabolario, sparse fra `lib/foods.ts`, `types/openfoodfacts.types.ts` e tre componenti.
+
+### Added
+- **Un test tiene ferma la cucitura fra il `CHECK` e gli enum Zod.** Ridurre il numero di definizioni non basta: le due che restano — il constraint, unico punto che rifiuta davvero una scrittura, e gli enum — possono ancora divergere, e lo farebbero in silenzio. `lib/__tests__/foodVocabulary.test.ts` legge i valori ammessi dal DDL delle migrazioni e li confronta con gli enum, e fallisce anche se una migrazione successiva ridefinisce quei constraint, perché a quel punto starebbe leggendo una riga di SQL superata.
+
 ## [1.11.1] - 2026-08-12
 
 ### Fixed
@@ -524,7 +532,8 @@ Lancio pubblico di Entro su LinkedIn.
 - Sistema di autenticazione Supabase completo
 - CRUD completo gestione alimenti con React Query
 
-[Unreleased]: https://github.com/E-Lop/entro/compare/v1.11.1...HEAD
+[Unreleased]: https://github.com/E-Lop/entro/compare/v1.11.2...HEAD
+[1.11.2]: https://github.com/E-Lop/entro/compare/v1.11.1...v1.11.2
 [1.11.1]: https://github.com/E-Lop/entro/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/E-Lop/entro/compare/v1.10.7...v1.11.0
 [1.10.7]: https://github.com/E-Lop/entro/compare/v1.10.6...v1.10.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entro",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entro",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entro",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.11.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/foods/FoodFilters.tsx
+++ b/src/components/foods/FoodFilters.tsx
@@ -5,6 +5,7 @@ import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
 import type { FilterParams } from '@/lib/foods'
 import type { Category } from '@/lib/foods'
+import type { StorageLocation } from '@/lib/validations/food.schemas'
 
 export interface FoodFiltersProps {
   filters: FilterParams
@@ -49,7 +50,7 @@ export function FoodFilters({
   const handleStorageChange = (value: string) => {
     onFiltersChange({
       ...filters,
-      storage_location: value ? (value as 'fridge' | 'freezer' | 'pantry') : undefined,
+      storage_location: value ? (value as StorageLocation) : undefined,
     })
   }
 

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -259,7 +259,7 @@ export function FoodForm({ mode, initialData, onSubmit, onCancel, isSubmitting =
       }
 
       if (mappedData.quantity_unit) {
-        form.setValue('quantity_unit', mappedData.quantity_unit as 'pz' | 'kg' | 'g' | 'l' | 'ml' | 'confezioni')
+        form.setValue('quantity_unit', mappedData.quantity_unit)
       }
 
       if (mappedData.notes) {

--- a/src/components/foods/QuickQuantityEditor.tsx
+++ b/src/components/foods/QuickQuantityEditor.tsx
@@ -7,7 +7,6 @@ import { QuantityStepper } from './QuantityStepper'
 import { useUpdateFood } from '@/hooks/useFoods'
 import { triggerHaptic } from '@/lib/haptics'
 import type { Food } from '@/lib/foods'
-import type { QuantityUnit } from '@/types/food.types'
 
 interface QuickQuantityEditorProps {
   food: Food
@@ -28,7 +27,7 @@ const PERSIST_DEBOUNCE_MS = 600
  */
 export function QuickQuantityEditor({ food, onOpenFullEdit }: QuickQuantityEditorProps) {
   const updateMutation = useUpdateFood()
-  const unit = food.quantity_unit as QuantityUnit | null
+  const unit = food.quantity_unit
 
   const [value, setValue] = useState<number | null>(food.quantity)
   const pendingRef = useRef<number | null>(food.quantity)

--- a/src/lib/__tests__/foodVocabulary.test.ts
+++ b/src/lib/__tests__/foodVocabulary.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Il vocabolario delle colonne `text` + CHECK, confrontato con gli enum Zod.
+ *
+ * `foods.status`, `foods.storage_location` e `foods.quantity_unit` non sono
+ * tipi `enum` di Postgres: sono `text` con un `CHECK`. Il generatore di tipi
+ * Supabase **non legge i check constraint**, quindi da `supabase gen types`
+ * escono `string | null` e il vocabolario si perde per strada.
+ *
+ * Il pavimento è quindi di due definizioni, non una: il CHECK, che è l'unico
+ * punto che rifiuta davvero una scrittura sbagliata — anche da un client che
+ * non è questo — e gli enum Zod, che sono la fonte unica lato TypeScript.
+ *
+ * Questo test tiene ferma la cucitura fra le due. Senza, la divergenza
+ * passerebbe in silenzio: è esattamente il modo in cui il difetto della issue
+ * #85 si è formato.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Food, FoodUpdate } from '@/lib/foods'
+import {
+  statusEnum,
+  storageLocationEnum,
+  quantityUnitEnum,
+} from '@/lib/validations/food.schemas'
+
+/**
+ * Asserzioni di tipo: non girano con vitest, si verificano con `tsc -b`.
+ *
+ * `@ts-expect-error` fallisce in **due** direzioni, ed è ciò che serve qui: se
+ * il tipo torna largo la direttiva diventa inutilizzata e il compilatore lo
+ * segnala. La riga è quindi rossa oggi, quando `Food['status']` è `string |
+ * null` e `'banana'` passa, e resta a guardia dopo.
+ */
+
+// @ts-expect-error — 'banana' non è un esito: il vocabolario è quello del CHECK
+export const esitoInventato: Food['status'] = 'banana'
+
+// @ts-expect-error — 'garage' non è un luogo di conservazione
+export const luogoInventato: Food['storage_location'] = 'garage'
+
+// @ts-expect-error — 'litri' non è un'unità: le unità sono 'l' e 'ml'
+export const unitaInventata: Food['quantity_unit'] = 'litri'
+
+// @ts-expect-error — nemmeno una UPDATE può scrivere un esito fuori vocabolario
+export const scritturaInventata: FoodUpdate = { status: 'banana' }
+
+const CARTELLA_MIGRAZIONI = join(process.cwd(), 'supabase', 'migrations')
+
+function fileMigrazione(): string[] {
+  return readdirSync(CARTELLA_MIGRAZIONI)
+    .filter((nome) => nome.endsWith('.sql'))
+    .map((nome) => readFileSync(join(CARTELLA_MIGRAZIONI, nome), 'utf8'))
+}
+
+/**
+ * Il corpo di `create table public.foods (...)`.
+ *
+ * Delimitare il blocco non è pignoleria: `invites` ha una colonna `status` con
+ * un CHECK suo (`pending`/`accepted`/`expired`), e un confronto fatto su tutto
+ * il file la scambierebbe per quella di `foods`, verificando la cosa sbagliata
+ * con l'aria di funzionare.
+ */
+function corpoTabellaFoods(): string {
+  const blocchi = fileMigrazione().flatMap((sql) => {
+    const inizio = sql.indexOf('create table public.foods (')
+    if (inizio === -1) return []
+    const fine = sql.indexOf('\n);', inizio)
+    return [sql.slice(inizio, fine)]
+  })
+
+  expect(
+    blocchi,
+    'atteso un solo `create table public.foods` fra le migrazioni'
+  ).toHaveLength(1)
+
+  return blocchi[0]
+}
+
+/** I valori fra apici dentro `<colonna> = any (array[...])`. */
+function valoriAmmessiDalCheck(colonna: string): string[] {
+  const pattern = new RegExp(
+    `${colonna}\\s*=\\s*any\\s*\\(\\s*array\\[([^\\]]*)\\]`,
+    'i'
+  )
+  const trovato = corpoTabellaFoods().match(pattern)
+
+  expect(trovato, `nessun CHECK trovato per la colonna ${colonna}`).not.toBeNull()
+
+  return [...trovato![1].matchAll(/'([^']*)'/g)].map((m) => m[1])
+}
+
+describe('vocabolario delle colonne text + CHECK', () => {
+  it.each([
+    ['status', statusEnum],
+    ['storage_location', storageLocationEnum],
+    ['quantity_unit', quantityUnitEnum],
+  ])('l\'enum Zod di %s elenca gli stessi valori del CHECK', (colonna, enumZod) => {
+    expect([...enumZod.options].sort()).toEqual(valoriAmmessiDalCheck(colonna).sort())
+  })
+
+  /**
+   * Il confronto qui sopra legge la definizione originale della tabella. Una
+   * migrazione successiva che sostituisse il constraint lo lascerebbe passare
+   * mentre verifica una riga di SQL ormai superata — cioè un test verde che non
+   * prova più niente. Meglio farlo fallire e costringere a riscriverlo.
+   */
+  it('nessuna migrazione successiva ridefinisce quei CHECK', () => {
+    const ridefinizioni = fileMigrazione().flatMap((sql) => [
+      ...sql.matchAll(
+        /alter\s+table[^;]*\bfoods\b[^;]*\bcheck\b[^;]*\b(status|storage_location|quantity_unit)\b/gis
+      ),
+    ])
+
+    expect(
+      ridefinizioni.map((m) => m[0]),
+      'un CHECK è stato ridefinito: aggiorna questo test perché legga la definizione valida'
+    ).toEqual([])
+  })
+})

--- a/src/lib/foods.ts
+++ b/src/lib/foods.ts
@@ -4,6 +4,7 @@ import { deleteFoodImage } from './storage'
 import { isPendingUrl, deletePendingImage } from './pendingImages'
 import { logError } from './safeLog'
 import { EXPIRY_SOON_DAYS } from './expiry'
+import type { StorageLocation } from './validations/food.schemas'
 
 /**
  * Foods Service Layer - Wrapper functions around Supabase Foods API
@@ -35,7 +36,7 @@ export interface CategoriesResponse {
  */
 export interface FilterParams {
   category_id?: string
-  storage_location?: 'fridge' | 'freezer' | 'pantry'
+  storage_location?: StorageLocation
   /** Filtro sulla scadenza, derivata dalla data. Da non confondere con
    *  `Food['status']`, che è l'esito scelto dall'utente. */
   expiry?: 'all' | 'not_expired' | 'expiring_soon' | 'expired'
@@ -313,13 +314,16 @@ async function discardFoodImage(imageUrl: string | null | undefined, userId: str
 /**
  * L'esito di un alimento tolto dalla lista, quando l'utente lo dichiara.
  *
- * Scritto a mano e non derivato da `Food['status']`, che nei tipi generati è
- * `string | null` e quindi non vincola niente: il vocabolario vero sta nel
- * check constraint della tabella `foods` (`active`/`consumed`/`expired`/
- * `wasted`). Qui restano solo i due valori che una persona può *scegliere* —
- * `expired` si ricava dalla data e non è un esito che qualcuno dichiara.
+ * Derivato da `Food['status']`, che ora porta il vocabolario del check
+ * constraint invece del `string | null` dei tipi generati. Restano i valori che
+ * una persona può *scegliere*: `active` è lo stato di chi non ha ancora un
+ * esito, ed `expired` si ricava dalla data — nessuno lo dichiara.
+ *
+ * Derivarlo, invece di riscriverlo, fa sì che un cambio di vocabolario si
+ * presenti come errore di compilazione qui, dove va deciso se il valore nuovo è
+ * un esito dichiarabile.
  */
-export type FoodOutcome = 'consumed' | 'wasted'
+export type FoodOutcome = Exclude<NonNullable<Food['status']>, 'active' | 'expired'>
 
 /**
  * Toglie un alimento dalla lista registrandone l'esito, in una sola scrittura.

--- a/src/lib/openfoodfacts.ts
+++ b/src/lib/openfoodfacts.ts
@@ -228,6 +228,11 @@ function formatProductName(name: string, brands?: string): string {
 
 /**
  * Parse quantity string to number and unit
+ *
+ * L'unità qui è **volutamente più stretta** di `QuantityUnit` e non va derivata
+ * da lì: la regex qui sotto non riconosce `confezioni`, perché Open Food Facts
+ * non le codifica in quel campo. Restituire un tipo che comprende un valore che
+ * la funzione non può produrre sposterebbe il controllo su chi la chiama.
  */
 function parseQuantity(quantityString?: string): {
   quantity: number | undefined

--- a/src/lib/supabase.overrides.ts
+++ b/src/lib/supabase.overrides.ts
@@ -1,0 +1,63 @@
+/**
+ * I tipi generati, ristretti dove il generatore non arriva.
+ *
+ * `foods.status`, `foods.storage_location` e `foods.quantity_unit` sono colonne
+ * `text` con un `CHECK`, non tipi `enum` di Postgres. `supabase gen types` non
+ * legge i check constraint, quindi da `supabase.types.ts` escono come `string`
+ * e `string | null`: il vocabolario esiste nel database e si perde in
+ * TypeScript, dove `updateFoodStatus(id, 'banana')` compilava.
+ *
+ * Qui il vocabolario rientra, e viene da **una sola** fonte lato TypeScript:
+ * gli enum Zod di `validations/food.schemas.ts`, che sono anche l'unico dei
+ * punti che ridichiaravano quelle liste a *fare* qualcosa a runtime.
+ *
+ * Il restringimento è sicuro perché il CHECK lo garantisce: sono i valori che
+ * il database accetta, da qualunque client. Che le due liste restino uguali lo
+ * tiene fermo `__tests__/foodVocabulary.test.ts`.
+ *
+ * Questo file va tenuto separato da `supabase.types.ts`, che `npm run
+ * supabase:types` riscrive da capo a ogni rigenerazione.
+ */
+import type { Database as Generata } from './supabase.types'
+import type {
+  FoodStatus,
+  QuantityUnit,
+  StorageLocation,
+} from './validations/food.schemas'
+
+type TabelleGenerate = Generata['public']['Tables']
+
+/**
+ * Nullabilità e obbligatorietà ricalcano il DDL, non i desideri del codice:
+ * `status` ha un default ma **non** è `not null`, e un CHECK non rifiuta NULL.
+ * Restringere il vocabolario dichiarando anche non-nullo sarebbe scambiare una
+ * correzione per due.
+ */
+type VocabolarioRow = {
+  status: FoodStatus | null
+  storage_location: StorageLocation
+  quantity_unit: QuantityUnit | null
+}
+
+type VocabolarioInsert = {
+  status?: FoodStatus | null
+  storage_location: StorageLocation
+  quantity_unit?: QuantityUnit | null
+}
+
+type VocabolarioUpdate = Partial<VocabolarioInsert>
+
+type ColonneVocabolario = keyof VocabolarioRow
+
+type FoodsRistretta = {
+  Row: Omit<TabelleGenerate['foods']['Row'], ColonneVocabolario> & VocabolarioRow
+  Insert: Omit<TabelleGenerate['foods']['Insert'], ColonneVocabolario> & VocabolarioInsert
+  Update: Omit<TabelleGenerate['foods']['Update'], ColonneVocabolario> & VocabolarioUpdate
+  Relationships: TabelleGenerate['foods']['Relationships']
+}
+
+export type Database = Omit<Generata, 'public'> & {
+  public: Omit<Generata['public'], 'Tables'> & {
+    Tables: Omit<TabelleGenerate, 'foods'> & { foods: FoodsRistretta }
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,10 @@
 import { createClient } from '@supabase/supabase-js'
-import type { Database } from './supabase.types'
+// Non da `supabase.types`: la versione ristretta rimette il vocabolario che il
+// generatore perde. Passando di qui vale per tutti i consumatori e per il
+// client stesso, che così rifiuta anche le scritture fuori vocabolario.
+import type { Database } from './supabase.overrides'
 
-export type { Database } from './supabase.types'
+export type { Database } from './supabase.overrides'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY

--- a/src/lib/validations/food.schemas.ts
+++ b/src/lib/validations/food.schemas.ts
@@ -1,12 +1,31 @@
 import { z } from 'zod'
 
-// Storage location enum
+/**
+ * Il vocabolario delle tre colonne `text` + `CHECK` della tabella `foods`.
+ *
+ * Questi enum sono la **fonte unica lato TypeScript**: `types/food.types.ts` li
+ * riesporta e `lib/supabase.overrides.ts` li usa per restringere le righe che
+ * il generatore di tipi consegna come `string`. Non ridichiarare queste liste
+ * altrove — il compilatore non se ne accorgerebbe.
+ *
+ * Il vincolo vero resta il `CHECK` in Postgres, che è l'unico punto a rifiutare
+ * davvero una scrittura, anche da un client che non è questo. Che le due liste
+ * restino uguali lo tiene fermo `lib/__tests__/foodVocabulary.test.ts`.
+ */
+
 export const storageLocationEnum = z.enum(['fridge', 'freezer', 'pantry'])
 
-// Quantity unit enum (must match database constraint)
 export const quantityUnitEnum = z.enum(['pz', 'kg', 'g', 'l', 'ml', 'confezioni'])
 
-// Status enum
+/**
+ * `expired` è **deprecato**: resta nella lista perché il CHECK lo ammette e
+ * perché esistono righe che lo portano, ma non va usato in flussi nuovi — la
+ * scadenza si deriva dalla data, non si dichiara. Vedi `core/food-lifecycle.md`
+ * nel bundle condiviso.
+ *
+ * La nota vive qui e non su un tipo derivato perché ogni derivazione la
+ * perderebbe: `FoodOutcome` in `lib/foods.ts` lo esclude proprio per questo.
+ */
 export const statusEnum = z.enum(['active', 'consumed', 'expired', 'wasted'])
 
 // Food form schema for create/edit operations

--- a/src/types/food.types.ts
+++ b/src/types/food.types.ts
@@ -1,9 +1,18 @@
 // Core types for food items
-export type StorageLocation = 'fridge' | 'freezer' | 'pantry'
 
-export type FoodStatus = 'active' | 'consumed' | 'expired' | 'wasted'
+/**
+ * Il vocabolario non si ridichiara qui: la fonte unica lato TypeScript sono
+ * gli enum Zod di `validations/food.schemas.ts`, che sono anche l'unica delle
+ * definizioni a validare qualcosa a runtime. Il vincolo vero resta il `CHECK`
+ * in Postgres, l'unico punto che rifiuta una scrittura sbagliata.
+ */
+import type {
+  StorageLocation,
+  FoodStatus,
+  QuantityUnit,
+} from '@/lib/validations/food.schemas'
 
-export type QuantityUnit = 'pz' | 'kg' | 'g' | 'l' | 'ml' | 'confezioni'
+export type { StorageLocation, FoodStatus, QuantityUnit }
 
 export interface Food {
   id: string

--- a/src/types/openfoodfacts.types.ts
+++ b/src/types/openfoodfacts.types.ts
@@ -2,6 +2,7 @@
  * Open Food Facts API Types
  * Documentation: https://openfoodfacts.github.io/openfoodfacts-server/api/
  */
+import type { QuantityUnit, StorageLocation } from '@/lib/validations/food.schemas'
 
 /**
  * Main product response from Open Food Facts API
@@ -47,9 +48,9 @@ export interface MappedProductData {
   name: string
   category_id?: string
   suggestedCategory?: string
-  storage_location?: 'fridge' | 'freezer' | 'pantry'
+  storage_location?: StorageLocation
   quantity?: number
-  quantity_unit?: string
+  quantity_unit?: QuantityUnit
   image_url?: string
   notes?: string
 }
@@ -60,6 +61,6 @@ export interface MappedProductData {
 export interface CategoryMapping {
   offTags: string[]
   categoryNameIt: string
-  storageLocation: 'fridge' | 'freezer' | 'pantry'
+  storageLocation: StorageLocation
   shelfLifeDays?: number
 }


### PR DESCRIPTION
Chiude #85, seguendo la strada **B + C** della issue.

## Il difetto

`foods.status`, `foods.storage_location` e `foods.quantity_unit` sono colonne `text` con un `CHECK`, non tipi `enum` di Postgres. Il generatore di tipi Supabase **non legge i check constraint**, quindi da `supabase gen types` uscivano così:

```ts
status: string | null
storage_location: string
quantity_unit: string | null
```

Il vincolo esisteva solo nel database: `updateFoodStatus(id, 'banana')` compilava, e lo sbaglio si presentava come 400 a runtime invece che come errore del compilatore.

## Cosa cambia

**Gli enum Zod sono la fonte unica lato TypeScript.** Erano tre le definizioni che ridichiaravano quelle liste — `types/food.types.ts`, gli enum Zod, e la riga generata che non vincolava nulla — e gli enum sono gli unici a *fare* qualcosa: validano a runtime. `food.types.ts` ora li riesporta invece di riscriverli.

**`lib/supabase.overrides.ts` restringe le righe generate**, e il restringimento passa da `lib/supabase.ts`, cioè dal punto in cui il client viene costruito. Non è un dettaglio: così vale anche per le **scritture**, non solo per le letture, e una `UPDATE` fuori vocabolario non compila. Il file è separato da `supabase.types.ts` perché `npm run supabase:types` riscrive quello da capo.

**Nullabilità e obbligatorietà ricalcano il DDL**, non i desideri del codice: `status` ha un default ma non è `not null`, e un CHECK non rifiuta NULL. Restringere il vocabolario dichiarando anche non-nullo sarebbe stato scambiare una correzione per due.

## Il pavimento resta due, non una

TypeScript non legge il DDL mentre compila, e il `CHECK` deve restare perché è l'unico punto che rifiuta davvero una scrittura — anche da un client che non è questo. Quello che si poteva togliere era la duplicazione *dentro* TypeScript, e quella è andata.

Resta quindi una cucitura, e la parte C della issue è ciò che la rende rumorosa: `lib/__tests__/foodVocabulary.test.ts` legge i valori ammessi dal DDL delle migrazioni e li confronta con gli enum.

Due dettagli di quel test che valgono più del confronto in sé:

- **delimita il blocco `create table public.foods`**, perché `invites` ha una colonna `status` con un CHECK suo (`pending`/`accepted`/`expired`): un confronto fatto su tutto il file la scambierebbe per quella di `foods` e verificherebbe la cosa sbagliata con l'aria di funzionare;
- **fallisce se una migrazione successiva ridefinisce quei constraint**, perché a quel punto starebbe leggendo una riga di SQL superata — cioè un test verde che non prova più niente.

## Sei copie inline, non due

La issue ne citava due (`FoodFilters.tsx` e `QuickQuantityEditor.tsx`). Cercandole tutte ne sono uscite sei, e non si comportano allo stesso modo — vale la pena distinguerle, perché la issue dava per scontato che sparissero da sole:

| Punto | Esito |
|---|---|
| `QuickQuantityEditor.tsx:31` | Il cast **sparisce davvero**: i tipi ora combaciano |
| `FoodForm.tsx:262` | Il cast sparisce, ma perché ho stretto `MappedProductData.quantity_unit`, che era `string` |
| `FoodFilters.tsx:52` | **Il cast resta**: la sorgente è il valore di una `<select>`, cioè `string`, e nessuna derivazione di tipi lo restringe. Ora punta a `StorageLocation` invece di riscrivere la lista |
| `lib/foods.ts:38` (`FilterParams`) | Copia che la issue non contava: derivata |
| `types/openfoodfacts.types.ts:50,63` | Idem, due |

L'unica lista letterale sopravvissuta è `parseQuantity` in `openfoodfacts.ts:234`, ed è **corretta**: la sua regex non riconosce `confezioni` perché OFF non le codifica in quel campo, quindi un tipo di ritorno che le comprendesse sposterebbe il controllo su chi chiama. Ho aggiunto il commento che lo dice, così non viene «corretta» in una duplicazione.

## `expired` resta deprecato, e la nota sopravvive alla derivazione

`core/food-lifecycle.md` del bundle dice che `expired` resta nel tipo per compatibilità ma non va usato in flussi nuovi. Una union derivata dal database se lo riporta dentro — va bene, ma va fatto sapendolo. La nota vive ora accanto a `statusEnum`, che è la fonte: ogni derivazione a valle la perderebbe.

`FoodOutcome` in `lib/foods.ts` era scritto a mano proprio perché `Food['status']` non vincolava niente; quel motivo è caduto, quindi ora è derivato — `Exclude<NonNullable<Food['status']>, 'active' | 'expired'>`. Un cambio di vocabolario si presenta come errore di compilazione lì, che è il posto dove va deciso se il valore nuovo è un esito dichiarabile.

## Verifiche

`npx tsc -b --force` pulito · `npx vitest run` **317 test su 51 file** (313 preesistenti + 4) · `npx eslint .` 0 errori, 5 warning tutti preesistenti (`react-refresh/only-export-components`).

Il test dei tipi merita una riga a parte, perché è la prova che il restringimento è reale e non decorativo: le quattro asserzioni usano `@ts-expect-error`, che fallisce in **due** direzioni. Contro il codice di prima erano quattro `error TS2578: Unused '@ts-expect-error' directive` — cioè `'banana'` era davvero assegnabile. Ora sono verdi perché il tipo rifiuta.

Anche il test del vocabolario è nato verde, dato che le liste già combaciavano, quindi l'ho perturbato su entrambi i lati per vederlo fallire: aggiungendo `'banana'` a `statusEnum` (rosso che nomina il valore di troppo) e aggiungendo una migrazione finta con un `alter table … add constraint` (rosso della guardia, che cita lo statement).

## Una cosa della issue che non c'era da fare

La issue segnalava che `docs/private/RESUME_SESSION.md` descrive le colonne come `ENUM(...)`. Verificato: il file dice già `TEXT + CHECK`, e in `docs/private/` non c'è nessun `ENUM(`. Era già stato corretto.

## Fuori scopo, ma da dire

`types/food.types.ts` continua a dichiarare a mano un'interfaccia `Food` che duplica la forma della riga — usata solo da `realtime.types.ts` — accanto alla `Food` vera che viene dai tipi generati. È una duplicazione diversa da questa (la *forma*, non il *vocabolario*) e non l'ho toccata.

Le ramificazioni su `entro-mobile` — che ha lo stesso vocabolario in tre punti, con `supabase.types.ts` scritto a mano e già divergente sulla nullabilità — sono il passo successivo, insieme alla convenzione sorella di `expiry-status-ssot` per il bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)